### PR TITLE
Change types with one constructor into empty records

### DIFF
--- a/src/Jawa/Event/BeforeComplete.elm
+++ b/src/Jawa/Event/BeforeComplete.elm
@@ -1,4 +1,4 @@
-module Jawa.Event.BeforeComplete exposing (BeforeComplete(..), decoder, encoder)
+module Jawa.Event.BeforeComplete exposing (BeforeComplete, decoder, encoder)
 
 {-|
 
@@ -12,8 +12,8 @@ import Json.Encode
 
 {-| <https://docs.jwplayer.com/players/reference/advertising-events#onbeforecomplete>
 -}
-type BeforeComplete
-    = BeforeComplete
+type alias BeforeComplete =
+    {}
 
 
 {-| A JSON decoder.
@@ -21,7 +21,7 @@ type BeforeComplete
 decoder : Json.Decode.Decoder BeforeComplete
 decoder =
     Json.Decode.dict Json.Decode.value
-        |> Json.Decode.map (always BeforeComplete)
+        |> Json.Decode.map (always {})
 
 
 {-| A JSON encoder.

--- a/src/Jawa/Event/BufferFull.elm
+++ b/src/Jawa/Event/BufferFull.elm
@@ -1,4 +1,4 @@
-module Jawa.Event.BufferFull exposing (BufferFull(..), decoder, encoder)
+module Jawa.Event.BufferFull exposing (BufferFull, decoder, encoder)
 
 {-|
 
@@ -12,8 +12,8 @@ import Json.Encode
 
 {-| This event is not documented.
 -}
-type BufferFull
-    = BufferFull
+type alias BufferFull =
+    {}
 
 
 {-| A JSON decoder.
@@ -21,7 +21,7 @@ type BufferFull
 decoder : Json.Decode.Decoder BufferFull
 decoder =
     Json.Decode.dict Json.Decode.value
-        |> Json.Decode.map (always BufferFull)
+        |> Json.Decode.map (always {})
 
 
 {-| A JSON encoder.

--- a/src/Jawa/Event/Complete.elm
+++ b/src/Jawa/Event/Complete.elm
@@ -1,4 +1,4 @@
-module Jawa.Event.Complete exposing (Complete(..), decoder, encoder)
+module Jawa.Event.Complete exposing (Complete, decoder, encoder)
 
 {-|
 
@@ -12,8 +12,8 @@ import Json.Encode
 
 {-| <https://docs.jwplayer.com/players/reference/playback-events-1#oncomplete>
 -}
-type Complete
-    = Complete
+type alias Complete =
+    {}
 
 
 {-| A JSON decoder.
@@ -21,7 +21,7 @@ type Complete
 decoder : Json.Decode.Decoder Complete
 decoder =
     Json.Decode.dict Json.Decode.value
-        |> Json.Decode.map (always Complete)
+        |> Json.Decode.map (always {})
 
 
 {-| A JSON encoder.

--- a/src/Jawa/Event/DisplayClick.elm
+++ b/src/Jawa/Event/DisplayClick.elm
@@ -1,4 +1,4 @@
-module Jawa.Event.DisplayClick exposing (DisplayClick(..), decoder, encoder)
+module Jawa.Event.DisplayClick exposing (DisplayClick, decoder, encoder)
 
 {-|
 
@@ -12,8 +12,8 @@ import Json.Encode
 
 {-| <https://docs.jwplayer.com/players/reference/control-events#ondisplayclick>
 -}
-type DisplayClick
-    = DisplayClick
+type alias DisplayClick =
+    {}
 
 
 {-| A JSON decoder.
@@ -21,7 +21,7 @@ type DisplayClick
 decoder : Json.Decode.Decoder DisplayClick
 decoder =
     Json.Decode.dict Json.Decode.value
-        |> Json.Decode.map (always DisplayClick)
+        |> Json.Decode.map (always {})
 
 
 {-| A JSON encoder.

--- a/src/Jawa/Event/PlaylistComplete.elm
+++ b/src/Jawa/Event/PlaylistComplete.elm
@@ -1,4 +1,4 @@
-module Jawa.Event.PlaylistComplete exposing (PlaylistComplete(..), decoder, encoder)
+module Jawa.Event.PlaylistComplete exposing (PlaylistComplete, decoder, encoder)
 
 {-|
 
@@ -12,8 +12,8 @@ import Json.Encode
 
 {-| <https://docs.jwplayer.com/players/reference/advertising-events#onbeforecomplete>
 -}
-type PlaylistComplete
-    = PlaylistComplete
+type alias PlaylistComplete =
+    {}
 
 
 {-| A JSON decoder.
@@ -21,7 +21,7 @@ type PlaylistComplete
 decoder : Json.Decode.Decoder PlaylistComplete
 decoder =
     Json.Decode.dict Json.Decode.value
-        |> Json.Decode.map (always PlaylistComplete)
+        |> Json.Decode.map (always {})
 
 
 {-| A JSON encoder.

--- a/src/Jawa/Event/ProviderFirstFrame.elm
+++ b/src/Jawa/Event/ProviderFirstFrame.elm
@@ -1,4 +1,4 @@
-module Jawa.Event.ProviderFirstFrame exposing (ProviderFirstFrame(..), decoder, encoder)
+module Jawa.Event.ProviderFirstFrame exposing (ProviderFirstFrame, decoder, encoder)
 
 {-|
 
@@ -12,8 +12,8 @@ import Json.Encode
 
 {-| This event is not documented.
 -}
-type ProviderFirstFrame
-    = ProviderFirstFrame
+type alias ProviderFirstFrame =
+    {}
 
 
 {-| A JSON decoder.
@@ -21,7 +21,7 @@ type ProviderFirstFrame
 decoder : Json.Decode.Decoder ProviderFirstFrame
 decoder =
     Json.Decode.dict Json.Decode.value
-        |> Json.Decode.map (always ProviderFirstFrame)
+        |> Json.Decode.map (always {})
 
 
 {-| A JSON encoder.

--- a/src/Jawa/Event/Remove.elm
+++ b/src/Jawa/Event/Remove.elm
@@ -1,4 +1,4 @@
-module Jawa.Event.Remove exposing (Remove(..), decoder, encoder)
+module Jawa.Event.Remove exposing (Remove, decoder, encoder)
 
 {-|
 
@@ -12,8 +12,8 @@ import Json.Encode
 
 {-| <https://docs.jwplayer.com/players/reference/events-1#onremove>
 -}
-type Remove
-    = Remove
+type alias Remove =
+    {}
 
 
 {-| A JSON decoder.
@@ -21,7 +21,7 @@ type Remove
 decoder : Json.Decode.Decoder Remove
 decoder =
     Json.Decode.dict Json.Decode.value
-        |> Json.Decode.map (always Remove)
+        |> Json.Decode.map (always {})
 
 
 {-| A JSON encoder.

--- a/src/Jawa/Event/Seeked.elm
+++ b/src/Jawa/Event/Seeked.elm
@@ -1,4 +1,4 @@
-module Jawa.Event.Seeked exposing (Seeked(..), decoder, encoder)
+module Jawa.Event.Seeked exposing (Seeked, decoder, encoder)
 
 {-|
 
@@ -12,8 +12,8 @@ import Json.Encode
 
 {-| <https://docs.jwplayer.com/players/reference/seek-events-1#onseeked>
 -}
-type Seeked
-    = Seeked
+type alias Seeked =
+    {}
 
 
 {-| A JSON decoder.
@@ -21,7 +21,7 @@ type Seeked
 decoder : Json.Decode.Decoder Seeked
 decoder =
     Json.Decode.dict Json.Decode.value
-        |> Json.Decode.map (always Seeked)
+        |> Json.Decode.map (always {})
 
 
 {-| A JSON encoder.

--- a/src/Jawa/Event/UserActive.elm
+++ b/src/Jawa/Event/UserActive.elm
@@ -1,4 +1,4 @@
-module Jawa.Event.UserActive exposing (UserActive(..), decoder, encoder)
+module Jawa.Event.UserActive exposing (UserActive, decoder, encoder)
 
 {-|
 
@@ -12,8 +12,8 @@ import Json.Encode
 
 {-| This event is not documented.
 -}
-type UserActive
-    = UserActive
+type alias UserActive =
+    {}
 
 
 {-| A JSON decoder.
@@ -21,7 +21,7 @@ type UserActive
 decoder : Json.Decode.Decoder UserActive
 decoder =
     Json.Decode.dict Json.Decode.value
-        |> Json.Decode.map (always UserActive)
+        |> Json.Decode.map (always {})
 
 
 {-| A JSON encoder.

--- a/src/Jawa/Event/UserInactive.elm
+++ b/src/Jawa/Event/UserInactive.elm
@@ -1,4 +1,4 @@
-module Jawa.Event.UserInactive exposing (UserInactive(..), decoder, encoder)
+module Jawa.Event.UserInactive exposing (UserInactive, decoder, encoder)
 
 {-|
 
@@ -12,8 +12,8 @@ import Json.Encode
 
 {-| This event is not documented.
 -}
-type UserInactive
-    = UserInactive
+type alias UserInactive =
+    {}
 
 
 {-| A JSON decoder.
@@ -21,7 +21,7 @@ type UserInactive
 decoder : Json.Decode.Decoder UserInactive
 decoder =
     Json.Decode.dict Json.Decode.value
-        |> Json.Decode.map (always UserInactive)
+        |> Json.Decode.map (always {})
 
 
 {-| A JSON encoder.

--- a/tests/Jawa/Event/BeforeCompleteTest.elm
+++ b/tests/Jawa/Event/BeforeCompleteTest.elm
@@ -18,10 +18,10 @@ test =
             BeforeComplete.encoder
             """ {
             } """
-            BeforeComplete.BeforeComplete
+            {}
         ]
 
 
 fuzzer : Fuzz.Fuzzer BeforeComplete.BeforeComplete
 fuzzer =
-    Fuzz.constant BeforeComplete.BeforeComplete
+    Fuzz.constant {}

--- a/tests/Jawa/Event/BufferFullTest.elm
+++ b/tests/Jawa/Event/BufferFullTest.elm
@@ -18,10 +18,10 @@ test =
             BufferFull.encoder
             """ {
             } """
-            BufferFull.BufferFull
+            {}
         ]
 
 
 fuzzer : Fuzz.Fuzzer BufferFull.BufferFull
 fuzzer =
-    Fuzz.constant BufferFull.BufferFull
+    Fuzz.constant {}

--- a/tests/Jawa/Event/CompleteTest.elm
+++ b/tests/Jawa/Event/CompleteTest.elm
@@ -18,10 +18,10 @@ test =
             Complete.encoder
             """ {
             } """
-            Complete.Complete
+            {}
         ]
 
 
 fuzzer : Fuzz.Fuzzer Complete.Complete
 fuzzer =
-    Fuzz.constant Complete.Complete
+    Fuzz.constant {}

--- a/tests/Jawa/Event/DisplayClickTest.elm
+++ b/tests/Jawa/Event/DisplayClickTest.elm
@@ -18,10 +18,10 @@ test =
             DisplayClick.encoder
             """ {
             } """
-            DisplayClick.DisplayClick
+            {}
         ]
 
 
 fuzzer : Fuzz.Fuzzer DisplayClick.DisplayClick
 fuzzer =
-    Fuzz.constant DisplayClick.DisplayClick
+    Fuzz.constant {}

--- a/tests/Jawa/Event/PlaylistCompleteTest.elm
+++ b/tests/Jawa/Event/PlaylistCompleteTest.elm
@@ -18,10 +18,10 @@ test =
             PlaylistComplete.encoder
             """ {
             } """
-            PlaylistComplete.PlaylistComplete
+            {}
         ]
 
 
 fuzzer : Fuzz.Fuzzer PlaylistComplete.PlaylistComplete
 fuzzer =
-    Fuzz.constant PlaylistComplete.PlaylistComplete
+    Fuzz.constant {}

--- a/tests/Jawa/Event/ProviderFirstFrameTest.elm
+++ b/tests/Jawa/Event/ProviderFirstFrameTest.elm
@@ -18,10 +18,10 @@ test =
             ProviderFirstFrame.encoder
             """ {
             } """
-            ProviderFirstFrame.ProviderFirstFrame
+            {}
         ]
 
 
 fuzzer : Fuzz.Fuzzer ProviderFirstFrame.ProviderFirstFrame
 fuzzer =
-    Fuzz.constant ProviderFirstFrame.ProviderFirstFrame
+    Fuzz.constant {}

--- a/tests/Jawa/Event/RemoveTest.elm
+++ b/tests/Jawa/Event/RemoveTest.elm
@@ -18,10 +18,10 @@ test =
             Remove.encoder
             """ {
             } """
-            Remove.Remove
+            {}
         ]
 
 
 fuzzer : Fuzz.Fuzzer Remove.Remove
 fuzzer =
-    Fuzz.constant Remove.Remove
+    Fuzz.constant {}

--- a/tests/Jawa/Event/SeekedTest.elm
+++ b/tests/Jawa/Event/SeekedTest.elm
@@ -18,10 +18,10 @@ test =
             Seeked.encoder
             """ {
             } """
-            Seeked.Seeked
+            {}
         ]
 
 
 fuzzer : Fuzz.Fuzzer Seeked.Seeked
 fuzzer =
-    Fuzz.constant Seeked.Seeked
+    Fuzz.constant {}

--- a/tests/Jawa/Event/UserActiveTest.elm
+++ b/tests/Jawa/Event/UserActiveTest.elm
@@ -18,10 +18,10 @@ test =
             UserActive.encoder
             """ {
             } """
-            UserActive.UserActive
+            {}
         ]
 
 
 fuzzer : Fuzz.Fuzzer UserActive.UserActive
 fuzzer =
-    Fuzz.constant UserActive.UserActive
+    Fuzz.constant {}

--- a/tests/Jawa/Event/UserInactiveTest.elm
+++ b/tests/Jawa/Event/UserInactiveTest.elm
@@ -18,10 +18,10 @@ test =
             UserInactive.encoder
             """ {
             } """
-            UserInactive.UserInactive
+            {}
         ]
 
 
 fuzzer : Fuzz.Fuzzer UserInactive.UserInactive
 fuzzer =
-    Fuzz.constant UserInactive.UserInactive
+    Fuzz.constant {}


### PR DESCRIPTION
This way they're consistent with the other types. And if JWP changes to introduce new fields, it will be easier to migrate. 