### PR TITLE
Rename `encoder` to `encode`

### DIFF
--- a/src/Jawa/AudioTrack.elm
+++ b/src/Jawa/AudioTrack.elm
@@ -1,8 +1,8 @@
-module Jawa.AudioTrack exposing (AudioTrack, decoder, encoder)
+module Jawa.AudioTrack exposing (AudioTrack, decoder, encode)
 
 {-|
 
-@docs AudioTrack, decoder, encoder
+@docs AudioTrack, decoder, encode
 
 -}
 
@@ -33,8 +33,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : AudioTrack -> Json.Encode.Value
-encoder x =
+encode : AudioTrack -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "autoselect", Json.Encode.bool x.autoselect )
         , ( "defaulttrack", Json.Encode.bool x.defaulttrack )

--- a/src/Jawa/CaptionTrack.elm
+++ b/src/Jawa/CaptionTrack.elm
@@ -1,8 +1,8 @@
-module Jawa.CaptionTrack exposing (CaptionTrack, decoder, encoder)
+module Jawa.CaptionTrack exposing (CaptionTrack, decoder, encode)
 
 {-|
 
-@docs CaptionTrack, decoder, encoder
+@docs CaptionTrack, decoder, encode
 
 -}
 
@@ -33,8 +33,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : CaptionTrack -> Json.Encode.Value
-encoder x =
+encode : CaptionTrack -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "id", Json.Encode.string x.id )
         , ( "label", Json.Encode.string x.label )

--- a/src/Jawa/Event.elm
+++ b/src/Jawa/Event.elm
@@ -1,8 +1,8 @@
-module Jawa.Event exposing (Event(..), decoder, encoder)
+module Jawa.Event exposing (Event(..), decoder, encode)
 
 {-|
 
-@docs Event, decoder, encoder
+@docs Event, decoder, encode
 
 -}
 
@@ -228,125 +228,125 @@ decoderWith string =
 
 {-| A JSON encoder.
 -}
-encoder : Event -> Json.Encode.Value
-encoder event =
+encode : Event -> Json.Encode.Value
+encode event =
     case event of
         AudioTracks x ->
-            encoderWith "audioTracks" Jawa.Event.AudioTracks.encoder x
+            encoderWith "audioTracks" Jawa.Event.AudioTracks.encode x
 
         BeforeComplete x ->
-            encoderWith "beforeComplete" Jawa.Event.BeforeComplete.encoder x
+            encoderWith "beforeComplete" Jawa.Event.BeforeComplete.encode x
 
         BeforePlay x ->
-            encoderWith "beforePlay" Jawa.Event.BeforePlay.encoder x
+            encoderWith "beforePlay" Jawa.Event.BeforePlay.encode x
 
         Breakpoint x ->
-            encoderWith "breakpoint" Jawa.Event.Breakpoint.encoder x
+            encoderWith "breakpoint" Jawa.Event.Breakpoint.encode x
 
         Buffer x ->
-            encoderWith "buffer" Jawa.Event.Buffer.encoder x
+            encoderWith "buffer" Jawa.Event.Buffer.encode x
 
         BufferChange x ->
-            encoderWith "bufferChange" Jawa.Event.BufferChange.encoder x
+            encoderWith "bufferChange" Jawa.Event.BufferChange.encode x
 
         BufferFull x ->
-            encoderWith "bufferFull" Jawa.Event.BufferFull.encoder x
+            encoderWith "bufferFull" Jawa.Event.BufferFull.encode x
 
         CaptionsChanged x ->
-            encoderWith "captionsChanged" Jawa.Event.CaptionsChanged.encoder x
+            encoderWith "captionsChanged" Jawa.Event.CaptionsChanged.encode x
 
         CaptionsList x ->
-            encoderWith "captionsList" Jawa.Event.CaptionsList.encoder x
+            encoderWith "captionsList" Jawa.Event.CaptionsList.encode x
 
         Click x ->
-            encoderWith "click" Jawa.Event.Click.encoder x
+            encoderWith "click" Jawa.Event.Click.encode x
 
         Complete x ->
-            encoderWith "complete" Jawa.Event.Complete.encoder x
+            encoderWith "complete" Jawa.Event.Complete.encode x
 
         Controls x ->
-            encoderWith "controls" Jawa.Event.Controls.encoder x
+            encoderWith "controls" Jawa.Event.Controls.encode x
 
         DisplayClick x ->
-            encoderWith "displayClick" Jawa.Event.DisplayClick.encoder x
+            encoderWith "displayClick" Jawa.Event.DisplayClick.encode x
 
         FirstFrame x ->
-            encoderWith "firstFrame" Jawa.Event.FirstFrame.encoder x
+            encoderWith "firstFrame" Jawa.Event.FirstFrame.encode x
 
         Fullscreen x ->
-            encoderWith "fullscreen" Jawa.Event.Fullscreen.encoder x
+            encoderWith "fullscreen" Jawa.Event.Fullscreen.encode x
 
         Idle x ->
-            encoderWith "idle" Jawa.Event.Idle.encoder x
+            encoderWith "idle" Jawa.Event.Idle.encode x
 
         MediaType x ->
-            encoderWith "mediaType" Jawa.Event.MediaType.encoder x
+            encoderWith "mediaType" Jawa.Event.MediaType.encode x
 
         Mute x ->
-            encoderWith "mute" Jawa.Event.Mute.encoder x
+            encoderWith "mute" Jawa.Event.Mute.encode x
 
         Pause x ->
-            encoderWith "pause" Jawa.Event.Pause.encoder x
+            encoderWith "pause" Jawa.Event.Pause.encode x
 
         PipEnter x ->
-            encoderWith "pipEnter" Jawa.Event.PipEnter.encoder x
+            encoderWith "pipEnter" Jawa.Event.PipEnter.encode x
 
         PipLeave x ->
-            encoderWith "pipLeave" Jawa.Event.PipLeave.encoder x
+            encoderWith "pipLeave" Jawa.Event.PipLeave.encode x
 
         Play x ->
-            encoderWith "play" Jawa.Event.Play.encoder x
+            encoderWith "play" Jawa.Event.Play.encode x
 
         PlaybackRateChanged x ->
-            encoderWith "playbackRateChanged" Jawa.Event.PlaybackRateChanged.encoder x
+            encoderWith "playbackRateChanged" Jawa.Event.PlaybackRateChanged.encode x
 
         Playlist x ->
-            encoderWith "playlist" Jawa.Event.Playlist.encoder x
+            encoderWith "playlist" Jawa.Event.Playlist.encode x
 
         PlaylistComplete x ->
-            encoderWith "playlistComplete" Jawa.Event.PlaylistComplete.encoder x
+            encoderWith "playlistComplete" Jawa.Event.PlaylistComplete.encode x
 
         PlaylistItem x ->
-            encoderWith "playlistItem" Jawa.Event.PlaylistItem.encoder x
+            encoderWith "playlistItem" Jawa.Event.PlaylistItem.encode x
 
         ProviderFirstFrame x ->
-            encoderWith "providerFirstFrame" Jawa.Event.ProviderFirstFrame.encoder x
+            encoderWith "providerFirstFrame" Jawa.Event.ProviderFirstFrame.encode x
 
         Ready x ->
-            encoderWith "ready" Jawa.Event.Ready.encoder x
+            encoderWith "ready" Jawa.Event.Ready.encode x
 
         Remove x ->
-            encoderWith "remove" Jawa.Event.Remove.encoder x
+            encoderWith "remove" Jawa.Event.Remove.encode x
 
         Resize x ->
-            encoderWith "resize" Jawa.Event.Resize.encoder x
+            encoderWith "resize" Jawa.Event.Resize.encode x
 
         Seek x ->
-            encoderWith "seek" Jawa.Event.Seek.encoder x
+            encoderWith "seek" Jawa.Event.Seek.encode x
 
         Seeked x ->
-            encoderWith "seeked" Jawa.Event.Seeked.encoder x
+            encoderWith "seeked" Jawa.Event.Seeked.encode x
 
         SetupError x ->
-            encoderWith "setupError" Jawa.Event.SetupError.encoder x
+            encoderWith "setupError" Jawa.Event.SetupError.encode x
 
         Time x ->
-            encoderWith "time" Jawa.Event.Time.encoder x
+            encoderWith "time" Jawa.Event.Time.encode x
 
         UserActive x ->
-            encoderWith "userActive" Jawa.Event.UserActive.encoder x
+            encoderWith "userActive" Jawa.Event.UserActive.encode x
 
         UserInactive x ->
-            encoderWith "userInactive" Jawa.Event.UserInactive.encoder x
+            encoderWith "userInactive" Jawa.Event.UserInactive.encode x
 
         Viewable x ->
-            encoderWith "viewable" Jawa.Event.Viewable.encoder x
+            encoderWith "viewable" Jawa.Event.Viewable.encode x
 
         VisualQuality x ->
-            encoderWith "visualQuality" Jawa.Event.VisualQuality.encoder x
+            encoderWith "visualQuality" Jawa.Event.VisualQuality.encode x
 
         Volume x ->
-            encoderWith "volume" Jawa.Event.Volume.encoder x
+            encoderWith "volume" Jawa.Event.Volume.encode x
 
 
 encoderWith : String -> (a -> Json.Decode.Value) -> a -> Json.Encode.Value

--- a/src/Jawa/Event.elm
+++ b/src/Jawa/Event.elm
@@ -232,125 +232,125 @@ encode : Event -> Json.Encode.Value
 encode event =
     case event of
         AudioTracks x ->
-            encoderWith "audioTracks" Jawa.Event.AudioTracks.encode x
+            encodeWith "audioTracks" Jawa.Event.AudioTracks.encode x
 
         BeforeComplete x ->
-            encoderWith "beforeComplete" Jawa.Event.BeforeComplete.encode x
+            encodeWith "beforeComplete" Jawa.Event.BeforeComplete.encode x
 
         BeforePlay x ->
-            encoderWith "beforePlay" Jawa.Event.BeforePlay.encode x
+            encodeWith "beforePlay" Jawa.Event.BeforePlay.encode x
 
         Breakpoint x ->
-            encoderWith "breakpoint" Jawa.Event.Breakpoint.encode x
+            encodeWith "breakpoint" Jawa.Event.Breakpoint.encode x
 
         Buffer x ->
-            encoderWith "buffer" Jawa.Event.Buffer.encode x
+            encodeWith "buffer" Jawa.Event.Buffer.encode x
 
         BufferChange x ->
-            encoderWith "bufferChange" Jawa.Event.BufferChange.encode x
+            encodeWith "bufferChange" Jawa.Event.BufferChange.encode x
 
         BufferFull x ->
-            encoderWith "bufferFull" Jawa.Event.BufferFull.encode x
+            encodeWith "bufferFull" Jawa.Event.BufferFull.encode x
 
         CaptionsChanged x ->
-            encoderWith "captionsChanged" Jawa.Event.CaptionsChanged.encode x
+            encodeWith "captionsChanged" Jawa.Event.CaptionsChanged.encode x
 
         CaptionsList x ->
-            encoderWith "captionsList" Jawa.Event.CaptionsList.encode x
+            encodeWith "captionsList" Jawa.Event.CaptionsList.encode x
 
         Click x ->
-            encoderWith "click" Jawa.Event.Click.encode x
+            encodeWith "click" Jawa.Event.Click.encode x
 
         Complete x ->
-            encoderWith "complete" Jawa.Event.Complete.encode x
+            encodeWith "complete" Jawa.Event.Complete.encode x
 
         Controls x ->
-            encoderWith "controls" Jawa.Event.Controls.encode x
+            encodeWith "controls" Jawa.Event.Controls.encode x
 
         DisplayClick x ->
-            encoderWith "displayClick" Jawa.Event.DisplayClick.encode x
+            encodeWith "displayClick" Jawa.Event.DisplayClick.encode x
 
         FirstFrame x ->
-            encoderWith "firstFrame" Jawa.Event.FirstFrame.encode x
+            encodeWith "firstFrame" Jawa.Event.FirstFrame.encode x
 
         Fullscreen x ->
-            encoderWith "fullscreen" Jawa.Event.Fullscreen.encode x
+            encodeWith "fullscreen" Jawa.Event.Fullscreen.encode x
 
         Idle x ->
-            encoderWith "idle" Jawa.Event.Idle.encode x
+            encodeWith "idle" Jawa.Event.Idle.encode x
 
         MediaType x ->
-            encoderWith "mediaType" Jawa.Event.MediaType.encode x
+            encodeWith "mediaType" Jawa.Event.MediaType.encode x
 
         Mute x ->
-            encoderWith "mute" Jawa.Event.Mute.encode x
+            encodeWith "mute" Jawa.Event.Mute.encode x
 
         Pause x ->
-            encoderWith "pause" Jawa.Event.Pause.encode x
+            encodeWith "pause" Jawa.Event.Pause.encode x
 
         PipEnter x ->
-            encoderWith "pipEnter" Jawa.Event.PipEnter.encode x
+            encodeWith "pipEnter" Jawa.Event.PipEnter.encode x
 
         PipLeave x ->
-            encoderWith "pipLeave" Jawa.Event.PipLeave.encode x
+            encodeWith "pipLeave" Jawa.Event.PipLeave.encode x
 
         Play x ->
-            encoderWith "play" Jawa.Event.Play.encode x
+            encodeWith "play" Jawa.Event.Play.encode x
 
         PlaybackRateChanged x ->
-            encoderWith "playbackRateChanged" Jawa.Event.PlaybackRateChanged.encode x
+            encodeWith "playbackRateChanged" Jawa.Event.PlaybackRateChanged.encode x
 
         Playlist x ->
-            encoderWith "playlist" Jawa.Event.Playlist.encode x
+            encodeWith "playlist" Jawa.Event.Playlist.encode x
 
         PlaylistComplete x ->
-            encoderWith "playlistComplete" Jawa.Event.PlaylistComplete.encode x
+            encodeWith "playlistComplete" Jawa.Event.PlaylistComplete.encode x
 
         PlaylistItem x ->
-            encoderWith "playlistItem" Jawa.Event.PlaylistItem.encode x
+            encodeWith "playlistItem" Jawa.Event.PlaylistItem.encode x
 
         ProviderFirstFrame x ->
-            encoderWith "providerFirstFrame" Jawa.Event.ProviderFirstFrame.encode x
+            encodeWith "providerFirstFrame" Jawa.Event.ProviderFirstFrame.encode x
 
         Ready x ->
-            encoderWith "ready" Jawa.Event.Ready.encode x
+            encodeWith "ready" Jawa.Event.Ready.encode x
 
         Remove x ->
-            encoderWith "remove" Jawa.Event.Remove.encode x
+            encodeWith "remove" Jawa.Event.Remove.encode x
 
         Resize x ->
-            encoderWith "resize" Jawa.Event.Resize.encode x
+            encodeWith "resize" Jawa.Event.Resize.encode x
 
         Seek x ->
-            encoderWith "seek" Jawa.Event.Seek.encode x
+            encodeWith "seek" Jawa.Event.Seek.encode x
 
         Seeked x ->
-            encoderWith "seeked" Jawa.Event.Seeked.encode x
+            encodeWith "seeked" Jawa.Event.Seeked.encode x
 
         SetupError x ->
-            encoderWith "setupError" Jawa.Event.SetupError.encode x
+            encodeWith "setupError" Jawa.Event.SetupError.encode x
 
         Time x ->
-            encoderWith "time" Jawa.Event.Time.encode x
+            encodeWith "time" Jawa.Event.Time.encode x
 
         UserActive x ->
-            encoderWith "userActive" Jawa.Event.UserActive.encode x
+            encodeWith "userActive" Jawa.Event.UserActive.encode x
 
         UserInactive x ->
-            encoderWith "userInactive" Jawa.Event.UserInactive.encode x
+            encodeWith "userInactive" Jawa.Event.UserInactive.encode x
 
         Viewable x ->
-            encoderWith "viewable" Jawa.Event.Viewable.encode x
+            encodeWith "viewable" Jawa.Event.Viewable.encode x
 
         VisualQuality x ->
-            encoderWith "visualQuality" Jawa.Event.VisualQuality.encode x
+            encodeWith "visualQuality" Jawa.Event.VisualQuality.encode x
 
         Volume x ->
-            encoderWith "volume" Jawa.Event.Volume.encode x
+            encodeWith "volume" Jawa.Event.Volume.encode x
 
 
-encoderWith : String -> (a -> Json.Decode.Value) -> a -> Json.Encode.Value
-encoderWith t f x =
+encodeWith : String -> (a -> Json.Decode.Value) -> a -> Json.Encode.Value
+encodeWith t f x =
     let
         json : Json.Encode.Value
         json =

--- a/src/Jawa/Event/AudioTracks.elm
+++ b/src/Jawa/Event/AudioTracks.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.AudioTracks exposing (AudioTracks, decoder, encoder)
+module Jawa.Event.AudioTracks exposing (AudioTracks, decoder, encode)
 
 {-|
 
-@docs AudioTracks, decoder, encoder
+@docs AudioTracks, decoder, encode
 
 -}
 
@@ -30,9 +30,9 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : AudioTracks -> Json.Encode.Value
-encoder x =
+encode : AudioTracks -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "currentTrack", Json.Encode.int x.currentTrack )
-        , ( "tracks", Json.Encode.list Jawa.AudioTrack.encoder x.tracks )
+        , ( "tracks", Json.Encode.list Jawa.AudioTrack.encode x.tracks )
         ]

--- a/src/Jawa/Event/BeforeComplete.elm
+++ b/src/Jawa/Event/BeforeComplete.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.BeforeComplete exposing (BeforeComplete, decoder, encoder)
+module Jawa.Event.BeforeComplete exposing (BeforeComplete, decoder, encode)
 
 {-|
 
-@docs BeforeComplete, decoder, encoder
+@docs BeforeComplete, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : BeforeComplete -> Json.Encode.Value
-encoder _ =
+encode : BeforeComplete -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/BeforePlay.elm
+++ b/src/Jawa/Event/BeforePlay.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.BeforePlay exposing (BeforePlay, decoder, encoder)
+module Jawa.Event.BeforePlay exposing (BeforePlay, decoder, encode)
 
 {-|
 
-@docs BeforePlay, decoder, encoder
+@docs BeforePlay, decoder, encode
 
 -}
 
@@ -31,9 +31,9 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : BeforePlay -> Json.Encode.Value
-encoder x =
+encode : BeforePlay -> Json.Encode.Value
+encode x =
     Json.Encode.object
-        [ ( "playReason", Jawa.PlayReason.encoder x.playReason )
-        , ( "viewable", Jawa.Viewable.encoder x.viewable )
+        [ ( "playReason", Jawa.PlayReason.encode x.playReason )
+        , ( "viewable", Jawa.Viewable.encode x.viewable )
         ]

--- a/src/Jawa/Event/Breakpoint.elm
+++ b/src/Jawa/Event/Breakpoint.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Breakpoint exposing (Breakpoint, decoder, encoder)
+module Jawa.Event.Breakpoint exposing (Breakpoint, decoder, encode)
 
 {-|
 
-@docs Breakpoint, decoder, encoder
+@docs Breakpoint, decoder, encode
 
 -}
 
@@ -27,8 +27,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Breakpoint -> Json.Encode.Value
-encoder x =
+encode : Breakpoint -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "breakpoint", Json.Encode.int x.breakpoint )
         ]

--- a/src/Jawa/Event/Buffer.elm
+++ b/src/Jawa/Event/Buffer.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Buffer exposing (Buffer, decoder, encoder)
+module Jawa.Event.Buffer exposing (Buffer, decoder, encode)
 
 {-|
 
-@docs Buffer, decoder, encoder
+@docs Buffer, decoder, encode
 
 -}
 
@@ -32,10 +32,10 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Buffer -> Json.Encode.Value
-encoder x =
+encode : Buffer -> Json.Encode.Value
+encode x =
     Json.Encode.object
-        [ ( "newstate", Jawa.State.encoder x.newstate )
-        , ( "oldstate", Jawa.State.encoder x.oldstate )
-        , ( "reason", Jawa.State.encoder x.reason )
+        [ ( "newstate", Jawa.State.encode x.newstate )
+        , ( "oldstate", Jawa.State.encode x.oldstate )
+        , ( "reason", Jawa.State.encode x.reason )
         ]

--- a/src/Jawa/Event/BufferChange.elm
+++ b/src/Jawa/Event/BufferChange.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.BufferChange exposing (BufferChange, decoder, encoder)
+module Jawa.Event.BufferChange exposing (BufferChange, decoder, encode)
 
 {-|
 
-@docs BufferChange, decoder, encoder
+@docs BufferChange, decoder, encode
 
 -}
 
@@ -36,12 +36,12 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : BufferChange -> Json.Encode.Value
-encoder x =
+encode : BufferChange -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "bufferPercent", Json.Encode.float x.bufferPercent )
         , ( "currentTime", Json.Encode.float x.currentTime )
         , ( "duration", Json.Encode.float x.duration )
         , ( "position", Json.Encode.float x.position )
-        , ( "seekRange", Jawa.SeekRange.encoder x.seekRange )
+        , ( "seekRange", Jawa.SeekRange.encode x.seekRange )
         ]

--- a/src/Jawa/Event/BufferFull.elm
+++ b/src/Jawa/Event/BufferFull.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.BufferFull exposing (BufferFull, decoder, encoder)
+module Jawa.Event.BufferFull exposing (BufferFull, decoder, encode)
 
 {-|
 
-@docs BufferFull, decoder, encoder
+@docs BufferFull, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : BufferFull -> Json.Encode.Value
-encoder _ =
+encode : BufferFull -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/CaptionsChanged.elm
+++ b/src/Jawa/Event/CaptionsChanged.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.CaptionsChanged exposing (CaptionsChanged, decoder, encoder)
+module Jawa.Event.CaptionsChanged exposing (CaptionsChanged, decoder, encode)
 
 {-|
 
-@docs CaptionsChanged, decoder, encoder
+@docs CaptionsChanged, decoder, encode
 
 -}
 
@@ -30,9 +30,9 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : CaptionsChanged -> Json.Encode.Value
-encoder x =
+encode : CaptionsChanged -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "track", Json.Encode.int x.track )
-        , ( "tracks", Json.Encode.list Jawa.CaptionTrack.encoder x.tracks )
+        , ( "tracks", Json.Encode.list Jawa.CaptionTrack.encode x.tracks )
         ]

--- a/src/Jawa/Event/CaptionsList.elm
+++ b/src/Jawa/Event/CaptionsList.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.CaptionsList exposing (CaptionsList, decoder, encoder)
+module Jawa.Event.CaptionsList exposing (CaptionsList, decoder, encode)
 
 {-|
 
-@docs CaptionsList, decoder, encoder
+@docs CaptionsList, decoder, encode
 
 -}
 
@@ -30,9 +30,9 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : CaptionsList -> Json.Encode.Value
-encoder x =
+encode : CaptionsList -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "track", Json.Encode.int x.track )
-        , ( "tracks", Json.Encode.list Jawa.CaptionTrack.encoder x.tracks )
+        , ( "tracks", Json.Encode.list Jawa.CaptionTrack.encode x.tracks )
         ]

--- a/src/Jawa/Event/Click.elm
+++ b/src/Jawa/Event/Click.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Click exposing (Click, decoder, encoder)
+module Jawa.Event.Click exposing (Click, decoder, encode)
 
 {-|
 
-@docs Click, decoder, encoder
+@docs Click, decoder, encode
 
 -}
 
@@ -27,8 +27,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Click -> Json.Encode.Value
-encoder x =
+encode : Click -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "isTrusted", Json.Encode.bool x.isTrusted )
         ]

--- a/src/Jawa/Event/Complete.elm
+++ b/src/Jawa/Event/Complete.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Complete exposing (Complete, decoder, encoder)
+module Jawa.Event.Complete exposing (Complete, decoder, encode)
 
 {-|
 
-@docs Complete, decoder, encoder
+@docs Complete, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Complete -> Json.Encode.Value
-encoder _ =
+encode : Complete -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/Controls.elm
+++ b/src/Jawa/Event/Controls.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Controls exposing (Controls, decoder, encoder)
+module Jawa.Event.Controls exposing (Controls, decoder, encode)
 
 {-|
 
-@docs Controls, decoder, encoder
+@docs Controls, decoder, encode
 
 -}
 
@@ -27,8 +27,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Controls -> Json.Encode.Value
-encoder x =
+encode : Controls -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "controls", Json.Encode.bool x.controls )
         ]

--- a/src/Jawa/Event/DisplayClick.elm
+++ b/src/Jawa/Event/DisplayClick.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.DisplayClick exposing (DisplayClick, decoder, encoder)
+module Jawa.Event.DisplayClick exposing (DisplayClick, decoder, encode)
 
 {-|
 
-@docs DisplayClick, decoder, encoder
+@docs DisplayClick, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : DisplayClick -> Json.Encode.Value
-encoder _ =
+encode : DisplayClick -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/FirstFrame.elm
+++ b/src/Jawa/Event/FirstFrame.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.FirstFrame exposing (FirstFrame, decoder, encoder)
+module Jawa.Event.FirstFrame exposing (FirstFrame, decoder, encode)
 
 {-|
 
-@docs FirstFrame, decoder, encoder
+@docs FirstFrame, decoder, encode
 
 -}
 
@@ -27,8 +27,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : FirstFrame -> Json.Encode.Value
-encoder x =
+encode : FirstFrame -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "loadTime", Json.Encode.float x.loadTime )
         ]

--- a/src/Jawa/Event/Fullscreen.elm
+++ b/src/Jawa/Event/Fullscreen.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Fullscreen exposing (Fullscreen, decoder, encoder)
+module Jawa.Event.Fullscreen exposing (Fullscreen, decoder, encode)
 
 {-|
 
-@docs Fullscreen, decoder, encoder
+@docs Fullscreen, decoder, encode
 
 -}
 
@@ -27,8 +27,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Fullscreen -> Json.Encode.Value
-encoder x =
+encode : Fullscreen -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "fullscreen", Json.Encode.bool x.fullscreen )
         ]

--- a/src/Jawa/Event/Idle.elm
+++ b/src/Jawa/Event/Idle.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Idle exposing (Idle, decoder, encoder)
+module Jawa.Event.Idle exposing (Idle, decoder, encode)
 
 {-|
 
-@docs Idle, decoder, encoder
+@docs Idle, decoder, encode
 
 -}
 
@@ -32,10 +32,10 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Idle -> Json.Encode.Value
-encoder x =
+encode : Idle -> Json.Encode.Value
+encode x =
     Json.Encode.object
-        [ ( "newstate", Jawa.State.encoder x.newstate )
-        , ( "oldstate", Jawa.State.encoder x.oldstate )
-        , ( "reason", Jawa.State.encoder x.reason )
+        [ ( "newstate", Jawa.State.encode x.newstate )
+        , ( "oldstate", Jawa.State.encode x.oldstate )
+        , ( "reason", Jawa.State.encode x.reason )
         ]

--- a/src/Jawa/Event/MediaType.elm
+++ b/src/Jawa/Event/MediaType.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.MediaType exposing (MediaType, decoder, encoder)
+module Jawa.Event.MediaType exposing (MediaType, decoder, encode)
 
 {-|
 
-@docs MediaType, decoder, encoder
+@docs MediaType, decoder, encode
 
 -}
 
@@ -28,8 +28,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : MediaType -> Json.Encode.Value
-encoder x =
+encode : MediaType -> Json.Encode.Value
+encode x =
     Json.Encode.object
-        [ ( "mediaType", Jawa.MediaType.encoder x.mediaType )
+        [ ( "mediaType", Jawa.MediaType.encode x.mediaType )
         ]

--- a/src/Jawa/Event/Mute.elm
+++ b/src/Jawa/Event/Mute.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Mute exposing (Mute, decoder, encoder)
+module Jawa.Event.Mute exposing (Mute, decoder, encode)
 
 {-|
 
-@docs Mute, decoder, encoder
+@docs Mute, decoder, encode
 
 -}
 
@@ -27,8 +27,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Mute -> Json.Encode.Value
-encoder x =
+encode : Mute -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "mute", Json.Encode.bool x.mute )
         ]

--- a/src/Jawa/Event/Pause.elm
+++ b/src/Jawa/Event/Pause.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Pause exposing (Pause, decoder, encoder)
+module Jawa.Event.Pause exposing (Pause, decoder, encode)
 
 {-|
 
-@docs Pause, decoder, encoder
+@docs Pause, decoder, encode
 
 -}
 
@@ -38,12 +38,12 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Pause -> Json.Encode.Value
-encoder x =
+encode : Pause -> Json.Encode.Value
+encode x =
     Json.Encode.object
-        [ ( "newstate", Jawa.State.encoder x.newstate )
-        , ( "oldstate", Jawa.State.encoder x.oldstate )
-        , ( "pauseReason", Jawa.PauseReason.encoder x.pauseReason )
-        , ( "reason", Jawa.State.encoder x.reason )
-        , ( "viewable", Jawa.Viewable.encoder x.viewable )
+        [ ( "newstate", Jawa.State.encode x.newstate )
+        , ( "oldstate", Jawa.State.encode x.oldstate )
+        , ( "pauseReason", Jawa.PauseReason.encode x.pauseReason )
+        , ( "reason", Jawa.State.encode x.reason )
+        , ( "viewable", Jawa.Viewable.encode x.viewable )
         ]

--- a/src/Jawa/Event/PipEnter.elm
+++ b/src/Jawa/Event/PipEnter.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.PipEnter exposing (PipEnter, decoder, encoder)
+module Jawa.Event.PipEnter exposing (PipEnter, decoder, encode)
 
 {-|
 
-@docs PipEnter, decoder, encoder
+@docs PipEnter, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : PipEnter -> Json.Encode.Value
-encoder _ =
+encode : PipEnter -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/PipLeave.elm
+++ b/src/Jawa/Event/PipLeave.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.PipLeave exposing (PipLeave, decoder, encoder)
+module Jawa.Event.PipLeave exposing (PipLeave, decoder, encode)
 
 {-|
 
-@docs PipLeave, decoder, encoder
+@docs PipLeave, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : PipLeave -> Json.Encode.Value
-encoder _ =
+encode : PipLeave -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/Play.elm
+++ b/src/Jawa/Event/Play.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Play exposing (Play, decoder, encoder)
+module Jawa.Event.Play exposing (Play, decoder, encode)
 
 {-|
 
-@docs Play, decoder, encoder
+@docs Play, decoder, encode
 
 -}
 
@@ -38,12 +38,12 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Play -> Json.Encode.Value
-encoder x =
+encode : Play -> Json.Encode.Value
+encode x =
     Json.Encode.object
-        [ ( "newstate", Jawa.State.encoder x.newstate )
-        , ( "oldstate", Jawa.State.encoder x.oldstate )
-        , ( "playReason", Jawa.PlayReason.encoder x.playReason )
-        , ( "reason", Jawa.State.encoder x.reason )
-        , ( "viewable", Jawa.Viewable.encoder x.viewable )
+        [ ( "newstate", Jawa.State.encode x.newstate )
+        , ( "oldstate", Jawa.State.encode x.oldstate )
+        , ( "playReason", Jawa.PlayReason.encode x.playReason )
+        , ( "reason", Jawa.State.encode x.reason )
+        , ( "viewable", Jawa.Viewable.encode x.viewable )
         ]

--- a/src/Jawa/Event/PlaybackRateChanged.elm
+++ b/src/Jawa/Event/PlaybackRateChanged.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.PlaybackRateChanged exposing (PlaybackRateChanged, decoder, encoder)
+module Jawa.Event.PlaybackRateChanged exposing (PlaybackRateChanged, decoder, encode)
 
 {-|
 
-@docs PlaybackRateChanged, decoder, encoder
+@docs PlaybackRateChanged, decoder, encode
 
 -}
 
@@ -27,8 +27,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : PlaybackRateChanged -> Json.Encode.Value
-encoder x =
+encode : PlaybackRateChanged -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "playbackRate", Json.Encode.float x.playbackRate )
         ]

--- a/src/Jawa/Event/Playlist.elm
+++ b/src/Jawa/Event/Playlist.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Playlist exposing (Playlist, decoder, encoder)
+module Jawa.Event.Playlist exposing (Playlist, decoder, encode)
 
 {-|
 
-@docs Playlist, decoder, encoder
+@docs Playlist, decoder, encode
 
 -}
 
@@ -28,8 +28,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Playlist -> Json.Encode.Value
-encoder x =
+encode : Playlist -> Json.Encode.Value
+encode x =
     Json.Encode.object
-        [ ( "playlist", Json.Encode.list Jawa.PlaylistItem.encoder x.playlist )
+        [ ( "playlist", Json.Encode.list Jawa.PlaylistItem.encode x.playlist )
         ]

--- a/src/Jawa/Event/PlaylistComplete.elm
+++ b/src/Jawa/Event/PlaylistComplete.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.PlaylistComplete exposing (PlaylistComplete, decoder, encoder)
+module Jawa.Event.PlaylistComplete exposing (PlaylistComplete, decoder, encode)
 
 {-|
 
-@docs PlaylistComplete, decoder, encoder
+@docs PlaylistComplete, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : PlaylistComplete -> Json.Encode.Value
-encoder _ =
+encode : PlaylistComplete -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/PlaylistItem.elm
+++ b/src/Jawa/Event/PlaylistItem.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.PlaylistItem exposing (PlaylistItem, decoder, encoder)
+module Jawa.Event.PlaylistItem exposing (PlaylistItem, decoder, encode)
 
 {-|
 
-@docs PlaylistItem, decoder, encoder
+@docs PlaylistItem, decoder, encode
 
 -}
 
@@ -30,9 +30,9 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : PlaylistItem -> Json.Encode.Value
-encoder x =
+encode : PlaylistItem -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "index", Json.Encode.int x.index )
-        , ( "item", Jawa.PlaylistItem.encoder x.item )
+        , ( "item", Jawa.PlaylistItem.encode x.item )
         ]

--- a/src/Jawa/Event/ProviderFirstFrame.elm
+++ b/src/Jawa/Event/ProviderFirstFrame.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.ProviderFirstFrame exposing (ProviderFirstFrame, decoder, encoder)
+module Jawa.Event.ProviderFirstFrame exposing (ProviderFirstFrame, decoder, encode)
 
 {-|
 
-@docs ProviderFirstFrame, decoder, encoder
+@docs ProviderFirstFrame, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : ProviderFirstFrame -> Json.Encode.Value
-encoder _ =
+encode : ProviderFirstFrame -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/Ready.elm
+++ b/src/Jawa/Event/Ready.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Ready exposing (Ready, decoder, encoder)
+module Jawa.Event.Ready exposing (Ready, decoder, encode)
 
 {-|
 
-@docs Ready, decoder, encoder
+@docs Ready, decoder, encode
 
 -}
 
@@ -30,9 +30,9 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Ready -> Json.Encode.Value
-encoder x =
+encode : Ready -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "setupTime", Json.Encode.float x.setupTime )
-        , ( "viewable", Jawa.Viewable.encoder x.viewable )
+        , ( "viewable", Jawa.Viewable.encode x.viewable )
         ]

--- a/src/Jawa/Event/Remove.elm
+++ b/src/Jawa/Event/Remove.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Remove exposing (Remove, decoder, encoder)
+module Jawa.Event.Remove exposing (Remove, decoder, encode)
 
 {-|
 
-@docs Remove, decoder, encoder
+@docs Remove, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Remove -> Json.Encode.Value
-encoder _ =
+encode : Remove -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/Resize.elm
+++ b/src/Jawa/Event/Resize.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Resize exposing (Resize, decoder, encoder)
+module Jawa.Event.Resize exposing (Resize, decoder, encode)
 
 {-|
 
-@docs Resize, decoder, encoder
+@docs Resize, decoder, encode
 
 -}
 
@@ -29,8 +29,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Resize -> Json.Encode.Value
-encoder x =
+encode : Resize -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "height", Json.Encode.int x.height )
         , ( "width", Json.Encode.int x.width )

--- a/src/Jawa/Event/Seek.elm
+++ b/src/Jawa/Event/Seek.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Seek exposing (Seek, decoder, encoder)
+module Jawa.Event.Seek exposing (Seek, decoder, encode)
 
 {-|
 
-@docs Seek, decoder, encoder
+@docs Seek, decoder, encode
 
 -}
 
@@ -39,13 +39,13 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Seek -> Json.Encode.Value
-encoder x =
+encode : Seek -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "currentTime", Json.Encode.float x.currentTime )
         , ( "duration", Json.Encode.float x.duration )
-        , ( "metadata", Jawa.Metadata.encoder x.metadata )
+        , ( "metadata", Jawa.Metadata.encode x.metadata )
         , ( "offset", Json.Encode.float x.offset )
         , ( "position", Json.Encode.float x.position )
-        , ( "seekRange", Jawa.SeekRange.encoder x.seekRange )
+        , ( "seekRange", Jawa.SeekRange.encode x.seekRange )
         ]

--- a/src/Jawa/Event/Seeked.elm
+++ b/src/Jawa/Event/Seeked.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Seeked exposing (Seeked, decoder, encoder)
+module Jawa.Event.Seeked exposing (Seeked, decoder, encode)
 
 {-|
 
-@docs Seeked, decoder, encoder
+@docs Seeked, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Seeked -> Json.Encode.Value
-encoder _ =
+encode : Seeked -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/SetupError.elm
+++ b/src/Jawa/Event/SetupError.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.SetupError exposing (SetupError, decoder, encoder)
+module Jawa.Event.SetupError exposing (SetupError, decoder, encode)
 
 {-|
 
-@docs SetupError, decoder, encoder
+@docs SetupError, decoder, encode
 
 -}
 
@@ -29,8 +29,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : SetupError -> Json.Encode.Value
-encoder x =
+encode : SetupError -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "code", Json.Encode.int x.code )
         , ( "message", Json.Encode.string x.message )

--- a/src/Jawa/Event/Time.elm
+++ b/src/Jawa/Event/Time.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Time exposing (Time, decoder, encoder)
+module Jawa.Event.Time exposing (Time, decoder, encode)
 
 {-|
 
-@docs Time, decoder, encoder
+@docs Time, decoder, encode
 
 -}
 
@@ -40,13 +40,13 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Time -> Json.Encode.Value
-encoder x =
+encode : Time -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "currentTime", Json.Encode.float x.currentTime )
         , ( "duration", Json.Encode.float x.duration )
-        , ( "metadata", Jawa.Metadata.encoder x.metadata )
+        , ( "metadata", Jawa.Metadata.encode x.metadata )
         , ( "position", Json.Encode.float x.position )
-        , ( "seekRange", Jawa.SeekRange.encoder x.seekRange )
-        , ( "viewable", Jawa.Viewable.encoder x.viewable )
+        , ( "seekRange", Jawa.SeekRange.encode x.seekRange )
+        , ( "viewable", Jawa.Viewable.encode x.viewable )
         ]

--- a/src/Jawa/Event/UserActive.elm
+++ b/src/Jawa/Event/UserActive.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.UserActive exposing (UserActive, decoder, encoder)
+module Jawa.Event.UserActive exposing (UserActive, decoder, encode)
 
 {-|
 
-@docs UserActive, decoder, encoder
+@docs UserActive, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : UserActive -> Json.Encode.Value
-encoder _ =
+encode : UserActive -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/UserInactive.elm
+++ b/src/Jawa/Event/UserInactive.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.UserInactive exposing (UserInactive, decoder, encoder)
+module Jawa.Event.UserInactive exposing (UserInactive, decoder, encode)
 
 {-|
 
-@docs UserInactive, decoder, encoder
+@docs UserInactive, decoder, encode
 
 -}
 
@@ -26,7 +26,7 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : UserInactive -> Json.Encode.Value
-encoder _ =
+encode : UserInactive -> Json.Encode.Value
+encode _ =
     Json.Encode.object
         []

--- a/src/Jawa/Event/Viewable.elm
+++ b/src/Jawa/Event/Viewable.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Viewable exposing (Viewable, decoder, encoder)
+module Jawa.Event.Viewable exposing (Viewable, decoder, encode)
 
 {-|
 
-@docs Viewable, decoder, encoder
+@docs Viewable, decoder, encode
 
 -}
 
@@ -28,8 +28,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Viewable -> Json.Encode.Value
-encoder x =
+encode : Viewable -> Json.Encode.Value
+encode x =
     Json.Encode.object
-        [ ( "viewable", Jawa.Viewable.encoder x.viewable )
+        [ ( "viewable", Jawa.Viewable.encode x.viewable )
         ]

--- a/src/Jawa/Event/VisualQuality.elm
+++ b/src/Jawa/Event/VisualQuality.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.VisualQuality exposing (VisualQuality, decoder, encoder)
+module Jawa.Event.VisualQuality exposing (VisualQuality, decoder, encode)
 
 {-|
 
-@docs VisualQuality, decoder, encoder
+@docs VisualQuality, decoder, encode
 
 -}
 
@@ -34,10 +34,10 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : VisualQuality -> Json.Encode.Value
-encoder x =
+encode : VisualQuality -> Json.Encode.Value
+encode x =
     Json.Encode.object
-        [ ( "level", Jawa.QualityLevel.encoder x.level )
-        , ( "mode", Jawa.QualityMode.encoder x.mode )
-        , ( "reason", Jawa.QualityReason.encoder x.reason )
+        [ ( "level", Jawa.QualityLevel.encode x.level )
+        , ( "mode", Jawa.QualityMode.encode x.mode )
+        , ( "reason", Jawa.QualityReason.encode x.reason )
         ]

--- a/src/Jawa/Event/Volume.elm
+++ b/src/Jawa/Event/Volume.elm
@@ -1,8 +1,8 @@
-module Jawa.Event.Volume exposing (Volume, decoder, encoder)
+module Jawa.Event.Volume exposing (Volume, decoder, encode)
 
 {-|
 
-@docs Volume, decoder, encoder
+@docs Volume, decoder, encode
 
 -}
 
@@ -27,8 +27,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Volume -> Json.Encode.Value
-encoder x =
+encode : Volume -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "volume", Json.Encode.float x.volume )
         ]

--- a/src/Jawa/MediaType.elm
+++ b/src/Jawa/MediaType.elm
@@ -1,8 +1,8 @@
-module Jawa.MediaType exposing (MediaType(..), decoder, encoder)
+module Jawa.MediaType exposing (MediaType(..), decoder, encode)
 
 {-|
 
-@docs MediaType, decoder, encoder
+@docs MediaType, decoder, encode
 
 -}
 
@@ -41,8 +41,8 @@ fromString string =
 
 {-| A JSON encoder.
 -}
-encoder : MediaType -> Json.Encode.Value
-encoder =
+encode : MediaType -> Json.Encode.Value
+encode =
     toString >> Json.Encode.string
 
 

--- a/src/Jawa/Metadata.elm
+++ b/src/Jawa/Metadata.elm
@@ -1,8 +1,8 @@
-module Jawa.Metadata exposing (Metadata(..), decoder, encoder)
+module Jawa.Metadata exposing (Metadata(..), decoder, encode)
 
 {-|
 
-@docs Metadata, decoder, encoder
+@docs Metadata, decoder, encode
 
 -}
 
@@ -25,6 +25,6 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Metadata -> Json.Encode.Value
-encoder (Metadata value) =
+encode : Metadata -> Json.Encode.Value
+encode (Metadata value) =
     value

--- a/src/Jawa/PauseReason.elm
+++ b/src/Jawa/PauseReason.elm
@@ -1,8 +1,8 @@
-module Jawa.PauseReason exposing (PauseReason(..), decoder, encoder)
+module Jawa.PauseReason exposing (PauseReason(..), decoder, encode)
 
 {-|
 
-@docs PauseReason, decoder, encoder
+@docs PauseReason, decoder, encode
 
 -}
 
@@ -45,8 +45,8 @@ fromString string =
 
 {-| A JSON encoder.
 -}
-encoder : PauseReason -> Json.Encode.Value
-encoder =
+encode : PauseReason -> Json.Encode.Value
+encode =
     toString >> Json.Encode.string
 
 

--- a/src/Jawa/PlayReason.elm
+++ b/src/Jawa/PlayReason.elm
@@ -1,8 +1,8 @@
-module Jawa.PlayReason exposing (PlayReason(..), decoder, encoder)
+module Jawa.PlayReason exposing (PlayReason(..), decoder, encode)
 
 {-|
 
-@docs PlayReason, decoder, encoder
+@docs PlayReason, decoder, encode
 
 -}
 
@@ -57,8 +57,8 @@ fromString string =
 
 {-| A JSON encoder.
 -}
-encoder : PlayReason -> Json.Encode.Value
-encoder =
+encode : PlayReason -> Json.Encode.Value
+encode =
     toString >> Json.Encode.string
 
 

--- a/src/Jawa/PlaylistItem.elm
+++ b/src/Jawa/PlaylistItem.elm
@@ -1,8 +1,8 @@
-module Jawa.PlaylistItem exposing (PlaylistItem, decoder, encoder)
+module Jawa.PlaylistItem exposing (PlaylistItem, decoder, encode)
 
 {-|
 
-@docs PlaylistItem, decoder, encoder
+@docs PlaylistItem, decoder, encode
 
 -}
 
@@ -48,16 +48,16 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : PlaylistItem -> Json.Encode.Value
-encoder x =
+encode : PlaylistItem -> Json.Encode.Value
+encode x =
     Json.Encode.object
-        [ ( "allSources", Json.Encode.list Jawa.Source.encoder x.allSources )
+        [ ( "allSources", Json.Encode.list Jawa.Source.encode x.allSources )
         , ( "description", Json.Encode.Extra.maybe Json.Encode.string x.description )
         , ( "file", Json.Encode.string x.file )
         , ( "image", Json.Encode.Extra.maybe Json.Encode.string x.image )
         , ( "mediaId", Json.Encode.Extra.maybe Json.Encode.string x.mediaId )
-        , ( "preload", Jawa.Preload.encoder x.preload )
-        , ( "sources", Json.Encode.list Jawa.Source.encoder x.sources )
+        , ( "preload", Jawa.Preload.encode x.preload )
+        , ( "sources", Json.Encode.list Jawa.Source.encode x.sources )
         , ( "title", Json.Encode.Extra.maybe Json.Encode.string x.title )
-        , ( "tracks", Json.Encode.list Jawa.Track.encoder x.tracks )
+        , ( "tracks", Json.Encode.list Jawa.Track.encode x.tracks )
         ]

--- a/src/Jawa/Preload.elm
+++ b/src/Jawa/Preload.elm
@@ -1,8 +1,8 @@
-module Jawa.Preload exposing (Preload(..), decoder, encoder)
+module Jawa.Preload exposing (Preload(..), decoder, encode)
 
 {-|
 
-@docs Preload, decoder, encoder
+@docs Preload, decoder, encode
 
 -}
 
@@ -45,8 +45,8 @@ fromString string =
 
 {-| A JSON encoder.
 -}
-encoder : Preload -> Json.Encode.Value
-encoder =
+encode : Preload -> Json.Encode.Value
+encode =
     toString >> Json.Encode.string
 
 

--- a/src/Jawa/QualityLevel.elm
+++ b/src/Jawa/QualityLevel.elm
@@ -1,8 +1,8 @@
-module Jawa.QualityLevel exposing (QualityLevel, decoder, encoder)
+module Jawa.QualityLevel exposing (QualityLevel, decoder, encode)
 
 {-|
 
-@docs QualityLevel, decoder, encoder
+@docs QualityLevel, decoder, encode
 
 -}
 
@@ -35,8 +35,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : QualityLevel -> Json.Encode.Value
-encoder x =
+encode : QualityLevel -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "bitrate", Json.Encode.int x.bitrate )
         , ( "height", Json.Encode.int x.height )

--- a/src/Jawa/QualityMode.elm
+++ b/src/Jawa/QualityMode.elm
@@ -1,8 +1,8 @@
-module Jawa.QualityMode exposing (QualityMode(..), decoder, encoder)
+module Jawa.QualityMode exposing (QualityMode(..), decoder, encode)
 
 {-|
 
-@docs QualityMode, decoder, encoder
+@docs QualityMode, decoder, encode
 
 -}
 
@@ -41,8 +41,8 @@ fromString string =
 
 {-| A JSON encoder.
 -}
-encoder : QualityMode -> Json.Encode.Value
-encoder =
+encode : QualityMode -> Json.Encode.Value
+encode =
     toString >> Json.Encode.string
 
 

--- a/src/Jawa/QualityReason.elm
+++ b/src/Jawa/QualityReason.elm
@@ -1,8 +1,8 @@
-module Jawa.QualityReason exposing (QualityReason(..), decoder, encoder)
+module Jawa.QualityReason exposing (QualityReason(..), decoder, encode)
 
 {-|
 
-@docs QualityReason, decoder, encoder
+@docs QualityReason, decoder, encode
 
 -}
 
@@ -45,8 +45,8 @@ fromString string =
 
 {-| A JSON encoder.
 -}
-encoder : QualityReason -> Json.Encode.Value
-encoder =
+encode : QualityReason -> Json.Encode.Value
+encode =
     toString >> Json.Encode.string
 
 

--- a/src/Jawa/SeekRange.elm
+++ b/src/Jawa/SeekRange.elm
@@ -1,8 +1,8 @@
-module Jawa.SeekRange exposing (SeekRange, decoder, encoder)
+module Jawa.SeekRange exposing (SeekRange, decoder, encode)
 
 {-|
 
-@docs SeekRange, decoder, encoder
+@docs SeekRange, decoder, encode
 
 -}
 
@@ -29,8 +29,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : SeekRange -> Json.Encode.Value
-encoder x =
+encode : SeekRange -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "end", Json.Encode.float x.end )
         , ( "start", Json.Encode.float x.start )

--- a/src/Jawa/Source.elm
+++ b/src/Jawa/Source.elm
@@ -1,8 +1,8 @@
-module Jawa.Source exposing (Source, decoder, encoder)
+module Jawa.Source exposing (Source, decoder, encode)
 
 {-|
 
-@docs Source, decoder, encoder
+@docs Source, decoder, encode
 
 -}
 
@@ -33,8 +33,8 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Source -> Json.Encode.Value
-encoder x =
+encode : Source -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "default", Json.Encode.bool x.default )
         , ( "file", Json.Encode.string x.file )

--- a/src/Jawa/State.elm
+++ b/src/Jawa/State.elm
@@ -1,8 +1,8 @@
-module Jawa.State exposing (State(..), decoder, encoder)
+module Jawa.State exposing (State(..), decoder, encode)
 
 {-|
 
-@docs State, decoder, encoder
+@docs State, decoder, encode
 
 -}
 
@@ -65,8 +65,8 @@ fromString string =
 
 {-| A JSON encoder.
 -}
-encoder : State -> Json.Encode.Value
-encoder =
+encode : State -> Json.Encode.Value
+encode =
     toString >> Json.Encode.string
 
 

--- a/src/Jawa/Track.elm
+++ b/src/Jawa/Track.elm
@@ -1,8 +1,8 @@
-module Jawa.Track exposing (Track, decoder, encoder)
+module Jawa.Track exposing (Track, decoder, encode)
 
 {-|
 
-@docs Track, decoder, encoder
+@docs Track, decoder, encode
 
 -}
 
@@ -32,10 +32,10 @@ decoder =
 
 {-| A JSON encoder.
 -}
-encoder : Track -> Json.Encode.Value
-encoder x =
+encode : Track -> Json.Encode.Value
+encode x =
     Json.Encode.object
         [ ( "file", Json.Encode.string x.file )
-        , ( "kind", Jawa.TrackKind.encoder x.kind )
+        , ( "kind", Jawa.TrackKind.encode x.kind )
         , ( "label", Json.Encode.string x.label )
         ]

--- a/src/Jawa/TrackKind.elm
+++ b/src/Jawa/TrackKind.elm
@@ -1,8 +1,8 @@
-module Jawa.TrackKind exposing (TrackKind(..), decoder, encoder)
+module Jawa.TrackKind exposing (TrackKind(..), decoder, encode)
 
 {-|
 
-@docs TrackKind, decoder, encoder
+@docs TrackKind, decoder, encode
 
 -}
 
@@ -45,8 +45,8 @@ fromString string =
 
 {-| A JSON encoder.
 -}
-encoder : TrackKind -> Json.Encode.Value
-encoder =
+encode : TrackKind -> Json.Encode.Value
+encode =
     toString >> Json.Encode.string
 
 

--- a/src/Jawa/Viewable.elm
+++ b/src/Jawa/Viewable.elm
@@ -1,8 +1,8 @@
-module Jawa.Viewable exposing (Viewable(..), decoder, encoder)
+module Jawa.Viewable exposing (Viewable(..), decoder, encode)
 
 {-|
 
-@docs Viewable, decoder, encoder
+@docs Viewable, decoder, encode
 
 -}
 
@@ -41,8 +41,8 @@ fromInt int =
 
 {-| A JSON encoder.
 -}
-encoder : Viewable -> Json.Encode.Value
-encoder =
+encode : Viewable -> Json.Encode.Value
+encode =
     toInt >> Json.Encode.int
 
 

--- a/tests/Jawa/AudioTrackTest.elm
+++ b/tests/Jawa/AudioTrackTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.AudioTrack"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.AudioTrack.decoder Jawa.AudioTrack.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.AudioTrack.decoder Jawa.AudioTrack.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.AudioTrack.decoder
-            Jawa.AudioTrack.encoder
+            Jawa.AudioTrack.encode
             """ {
                 "autoselect": false,
                 "defaulttrack": true,

--- a/tests/Jawa/CaptionTrackTest.elm
+++ b/tests/Jawa/CaptionTrackTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.CaptionTrack"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.CaptionTrack.decoder Jawa.CaptionTrack.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.CaptionTrack.decoder Jawa.CaptionTrack.encode fuzzer
         , Jawa.Extra.Test.testCodec "works without language"
             Jawa.CaptionTrack.decoder
-            Jawa.CaptionTrack.encoder
+            Jawa.CaptionTrack.encode
             """ {
                 "id": "a",
                 "label": "b"
@@ -26,7 +26,7 @@ test =
             }
         , Jawa.Extra.Test.testCodec "works with language"
             Jawa.CaptionTrack.decoder
-            Jawa.CaptionTrack.encoder
+            Jawa.CaptionTrack.encode
             """ {
                 "id": "a",
                 "label": "b",

--- a/tests/Jawa/Event/AudioTracksTest.elm
+++ b/tests/Jawa/Event/AudioTracksTest.elm
@@ -13,10 +13,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.AudioTracks"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.AudioTracks.decoder Jawa.Event.AudioTracks.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.AudioTracks.decoder Jawa.Event.AudioTracks.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.AudioTracks.decoder
-            Jawa.Event.AudioTracks.encoder
+            Jawa.Event.AudioTracks.encode
             """ {
                 "currentTrack": 0,
                 "tracks": []

--- a/tests/Jawa/Event/BeforeCompleteTest.elm
+++ b/tests/Jawa/Event/BeforeCompleteTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.BeforeComplete"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.BeforeComplete.decoder Jawa.Event.BeforeComplete.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.BeforeComplete.decoder Jawa.Event.BeforeComplete.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.BeforeComplete.decoder
-            Jawa.Event.BeforeComplete.encoder
+            Jawa.Event.BeforeComplete.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/BeforePlayTest.elm
+++ b/tests/Jawa/Event/BeforePlayTest.elm
@@ -16,10 +16,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.BeforePlay"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.BeforePlay.decoder Jawa.Event.BeforePlay.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.BeforePlay.decoder Jawa.Event.BeforePlay.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.BeforePlay.decoder
-            Jawa.Event.BeforePlay.encoder
+            Jawa.Event.BeforePlay.encode
             """ {
                 "playReason": "autostart",
                 "viewable": 0

--- a/tests/Jawa/Event/BreakpointTest.elm
+++ b/tests/Jawa/Event/BreakpointTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Breakpoint"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Breakpoint.decoder Jawa.Event.Breakpoint.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Breakpoint.decoder Jawa.Event.Breakpoint.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Breakpoint.decoder
-            Jawa.Event.Breakpoint.encoder
+            Jawa.Event.Breakpoint.encode
             """ {
                 "breakpoint": 0
             } """

--- a/tests/Jawa/Event/BufferChangeTest.elm
+++ b/tests/Jawa/Event/BufferChangeTest.elm
@@ -13,10 +13,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.BufferChange"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.BufferChange.decoder Jawa.Event.BufferChange.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.BufferChange.decoder Jawa.Event.BufferChange.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.BufferChange.decoder
-            Jawa.Event.BufferChange.encoder
+            Jawa.Event.BufferChange.encode
             """ {
                 "bufferPercent": 0.1,
                 "currentTime": 0.2,

--- a/tests/Jawa/Event/BufferFullTest.elm
+++ b/tests/Jawa/Event/BufferFullTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.BufferFull"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.BufferFull.decoder Jawa.Event.BufferFull.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.BufferFull.decoder Jawa.Event.BufferFull.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.BufferFull.decoder
-            Jawa.Event.BufferFull.encoder
+            Jawa.Event.BufferFull.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/BufferTest.elm
+++ b/tests/Jawa/Event/BufferTest.elm
@@ -14,10 +14,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Buffer"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Buffer.decoder Jawa.Event.Buffer.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Buffer.decoder Jawa.Event.Buffer.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Buffer.decoder
-            Jawa.Event.Buffer.encoder
+            Jawa.Event.Buffer.encode
             """ {
                 "oldstate": "idle",
                 "newstate": "buffering",

--- a/tests/Jawa/Event/CaptionsChangedTest.elm
+++ b/tests/Jawa/Event/CaptionsChangedTest.elm
@@ -13,10 +13,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.CaptionsChanged"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.CaptionsChanged.decoder Jawa.Event.CaptionsChanged.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.CaptionsChanged.decoder Jawa.Event.CaptionsChanged.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.CaptionsChanged.decoder
-            Jawa.Event.CaptionsChanged.encoder
+            Jawa.Event.CaptionsChanged.encode
             """ {
                 "track": 0,
                 "tracks": []

--- a/tests/Jawa/Event/CaptionsListTest.elm
+++ b/tests/Jawa/Event/CaptionsListTest.elm
@@ -13,10 +13,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.CaptionsList"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.CaptionsList.decoder Jawa.Event.CaptionsList.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.CaptionsList.decoder Jawa.Event.CaptionsList.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.CaptionsList.decoder
-            Jawa.Event.CaptionsList.encoder
+            Jawa.Event.CaptionsList.encode
             """ {
                 "track": 0,
                 "tracks": []

--- a/tests/Jawa/Event/ClickTest.elm
+++ b/tests/Jawa/Event/ClickTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Click"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Click.decoder Jawa.Event.Click.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Click.decoder Jawa.Event.Click.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Click.decoder
-            Jawa.Event.Click.encoder
+            Jawa.Event.Click.encode
             """ {
                 "isTrusted": false
             } """

--- a/tests/Jawa/Event/CompleteTest.elm
+++ b/tests/Jawa/Event/CompleteTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Complete"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Complete.decoder Jawa.Event.Complete.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Complete.decoder Jawa.Event.Complete.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Complete.decoder
-            Jawa.Event.Complete.encoder
+            Jawa.Event.Complete.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/ControlsTest.elm
+++ b/tests/Jawa/Event/ControlsTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Controls"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Controls.decoder Jawa.Event.Controls.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Controls.decoder Jawa.Event.Controls.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Controls.decoder
-            Jawa.Event.Controls.encoder
+            Jawa.Event.Controls.encode
             """ {
                 "controls": false
             } """

--- a/tests/Jawa/Event/DisplayClickTest.elm
+++ b/tests/Jawa/Event/DisplayClickTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.DisplayClick"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.DisplayClick.decoder Jawa.Event.DisplayClick.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.DisplayClick.decoder Jawa.Event.DisplayClick.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.DisplayClick.decoder
-            Jawa.Event.DisplayClick.encoder
+            Jawa.Event.DisplayClick.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/FirstFrameTest.elm
+++ b/tests/Jawa/Event/FirstFrameTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.FirstFrame"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.FirstFrame.decoder Jawa.Event.FirstFrame.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.FirstFrame.decoder Jawa.Event.FirstFrame.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.FirstFrame.decoder
-            Jawa.Event.FirstFrame.encoder
+            Jawa.Event.FirstFrame.encode
             """ {
                 "loadTime": 0.1
             } """

--- a/tests/Jawa/Event/FullscreenTest.elm
+++ b/tests/Jawa/Event/FullscreenTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Fullscreen"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Fullscreen.decoder Jawa.Event.Fullscreen.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Fullscreen.decoder Jawa.Event.Fullscreen.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Fullscreen.decoder
-            Jawa.Event.Fullscreen.encoder
+            Jawa.Event.Fullscreen.encode
             """ {
                 "fullscreen": false
             } """

--- a/tests/Jawa/Event/IdleTest.elm
+++ b/tests/Jawa/Event/IdleTest.elm
@@ -14,10 +14,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Idle"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Idle.decoder Jawa.Event.Idle.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Idle.decoder Jawa.Event.Idle.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Idle.decoder
-            Jawa.Event.Idle.encoder
+            Jawa.Event.Idle.encode
             """ {
                 "newstate": "buffering",
                 "oldstate": "complete",

--- a/tests/Jawa/Event/MediaTypeTest.elm
+++ b/tests/Jawa/Event/MediaTypeTest.elm
@@ -14,10 +14,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.MediaType"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.MediaType.decoder Jawa.Event.MediaType.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.MediaType.decoder Jawa.Event.MediaType.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.MediaType.decoder
-            Jawa.Event.MediaType.encoder
+            Jawa.Event.MediaType.encode
             """ {
                 "mediaType": "audio"
             } """

--- a/tests/Jawa/Event/MuteTest.elm
+++ b/tests/Jawa/Event/MuteTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Mute"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Mute.decoder Jawa.Event.Mute.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Mute.decoder Jawa.Event.Mute.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Mute.decoder
-            Jawa.Event.Mute.encoder
+            Jawa.Event.Mute.encode
             """ {
                 "mute": false
             } """

--- a/tests/Jawa/Event/PauseTest.elm
+++ b/tests/Jawa/Event/PauseTest.elm
@@ -18,10 +18,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Pause"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Pause.decoder Jawa.Event.Pause.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Pause.decoder Jawa.Event.Pause.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Pause.decoder
-            Jawa.Event.Pause.encoder
+            Jawa.Event.Pause.encode
             """ {
                 "newstate": "buffering",
                 "oldstate": "complete",

--- a/tests/Jawa/Event/PipEnterTest.elm
+++ b/tests/Jawa/Event/PipEnterTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.PipEnter"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.PipEnter.decoder Jawa.Event.PipEnter.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.PipEnter.decoder Jawa.Event.PipEnter.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.PipEnter.decoder
-            Jawa.Event.PipEnter.encoder
+            Jawa.Event.PipEnter.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/PipLeaveTest.elm
+++ b/tests/Jawa/Event/PipLeaveTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.PipLeave"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.PipLeave.decoder Jawa.Event.PipLeave.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.PipLeave.decoder Jawa.Event.PipLeave.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.PipLeave.decoder
-            Jawa.Event.PipLeave.encoder
+            Jawa.Event.PipLeave.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/PlayTest.elm
+++ b/tests/Jawa/Event/PlayTest.elm
@@ -18,10 +18,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Play"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Play.decoder Jawa.Event.Play.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Play.decoder Jawa.Event.Play.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Play.decoder
-            Jawa.Event.Play.encoder
+            Jawa.Event.Play.encode
             """ {
                 "newstate": "buffering",
                 "oldstate": "complete",

--- a/tests/Jawa/Event/PlaybackRateChangedTest.elm
+++ b/tests/Jawa/Event/PlaybackRateChangedTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.PlaybackRateChanged"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.PlaybackRateChanged.decoder Jawa.Event.PlaybackRateChanged.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.PlaybackRateChanged.decoder Jawa.Event.PlaybackRateChanged.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.PlaybackRateChanged.decoder
-            Jawa.Event.PlaybackRateChanged.encoder
+            Jawa.Event.PlaybackRateChanged.encode
             """ {
                 "playbackRate": 0.1
             } """

--- a/tests/Jawa/Event/PlaylistCompleteTest.elm
+++ b/tests/Jawa/Event/PlaylistCompleteTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.PlaylistComplete"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.PlaylistComplete.decoder Jawa.Event.PlaylistComplete.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.PlaylistComplete.decoder Jawa.Event.PlaylistComplete.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.PlaylistComplete.decoder
-            Jawa.Event.PlaylistComplete.encoder
+            Jawa.Event.PlaylistComplete.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/PlaylistItemTest.elm
+++ b/tests/Jawa/Event/PlaylistItemTest.elm
@@ -14,10 +14,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.PlaylistItem"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.PlaylistItem.decoder Jawa.Event.PlaylistItem.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.PlaylistItem.decoder Jawa.Event.PlaylistItem.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.PlaylistItem.decoder
-            Jawa.Event.PlaylistItem.encoder
+            Jawa.Event.PlaylistItem.encode
             """ {
                 "index": 0,
                 "item": {

--- a/tests/Jawa/Event/PlaylistTest.elm
+++ b/tests/Jawa/Event/PlaylistTest.elm
@@ -13,10 +13,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Playlist"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Playlist.decoder Jawa.Event.Playlist.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Playlist.decoder Jawa.Event.Playlist.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Playlist.decoder
-            Jawa.Event.Playlist.encoder
+            Jawa.Event.Playlist.encode
             """ {
                 "playlist": []
             } """

--- a/tests/Jawa/Event/ProviderFirstFrameTest.elm
+++ b/tests/Jawa/Event/ProviderFirstFrameTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.ProviderFirstFrame"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.ProviderFirstFrame.decoder Jawa.Event.ProviderFirstFrame.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.ProviderFirstFrame.decoder Jawa.Event.ProviderFirstFrame.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.ProviderFirstFrame.decoder
-            Jawa.Event.ProviderFirstFrame.encoder
+            Jawa.Event.ProviderFirstFrame.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/ReadyTest.elm
+++ b/tests/Jawa/Event/ReadyTest.elm
@@ -14,10 +14,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Ready"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Ready.decoder Jawa.Event.Ready.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Ready.decoder Jawa.Event.Ready.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Ready.decoder
-            Jawa.Event.Ready.encoder
+            Jawa.Event.Ready.encode
             """ {
                 "setupTime": 0.1,
                 "viewable": 0

--- a/tests/Jawa/Event/RemoveTest.elm
+++ b/tests/Jawa/Event/RemoveTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Remove"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Remove.decoder Jawa.Event.Remove.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Remove.decoder Jawa.Event.Remove.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Remove.decoder
-            Jawa.Event.Remove.encoder
+            Jawa.Event.Remove.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/ResizeTest.elm
+++ b/tests/Jawa/Event/ResizeTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Resize"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Resize.decoder Jawa.Event.Resize.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Resize.decoder Jawa.Event.Resize.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Resize.decoder
-            Jawa.Event.Resize.encoder
+            Jawa.Event.Resize.encode
             """ {
                 "height": 0,
                 "width": 1

--- a/tests/Jawa/Event/SeekTest.elm
+++ b/tests/Jawa/Event/SeekTest.elm
@@ -16,10 +16,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Seek"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Seek.decoder Jawa.Event.Seek.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Seek.decoder Jawa.Event.Seek.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Seek.decoder
-            Jawa.Event.Seek.encoder
+            Jawa.Event.Seek.encode
             """ {
                 "currentTime": 0.1,
                 "duration": 0.2,

--- a/tests/Jawa/Event/SeekedTest.elm
+++ b/tests/Jawa/Event/SeekedTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Seeked"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Seeked.decoder Jawa.Event.Seeked.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Seeked.decoder Jawa.Event.Seeked.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Seeked.decoder
-            Jawa.Event.Seeked.encoder
+            Jawa.Event.Seeked.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/SetupErrorTest.elm
+++ b/tests/Jawa/Event/SetupErrorTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.SetupError"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.SetupError.decoder Jawa.Event.SetupError.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.SetupError.decoder Jawa.Event.SetupError.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.SetupError.decoder
-            Jawa.Event.SetupError.encoder
+            Jawa.Event.SetupError.encode
             """ {
                 "code": 0,
                 "message": ""

--- a/tests/Jawa/Event/TimeTest.elm
+++ b/tests/Jawa/Event/TimeTest.elm
@@ -18,10 +18,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Time"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Time.decoder Jawa.Event.Time.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Time.decoder Jawa.Event.Time.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Time.decoder
-            Jawa.Event.Time.encoder
+            Jawa.Event.Time.encode
             """ {
                 "currentTime": 0.1,
                 "duration": 0.2,

--- a/tests/Jawa/Event/UserActiveTest.elm
+++ b/tests/Jawa/Event/UserActiveTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.UserActive"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.UserActive.decoder Jawa.Event.UserActive.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.UserActive.decoder Jawa.Event.UserActive.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.UserActive.decoder
-            Jawa.Event.UserActive.encoder
+            Jawa.Event.UserActive.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/UserInactiveTest.elm
+++ b/tests/Jawa/Event/UserInactiveTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.UserInactive"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.UserInactive.decoder Jawa.Event.UserInactive.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.UserInactive.decoder Jawa.Event.UserInactive.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.UserInactive.decoder
-            Jawa.Event.UserInactive.encoder
+            Jawa.Event.UserInactive.encode
             """ {
             } """
             {}

--- a/tests/Jawa/Event/ViewableTest.elm
+++ b/tests/Jawa/Event/ViewableTest.elm
@@ -14,10 +14,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Viewable"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Viewable.decoder Jawa.Event.Viewable.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Viewable.decoder Jawa.Event.Viewable.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Viewable.decoder
-            Jawa.Event.Viewable.encoder
+            Jawa.Event.Viewable.encode
             """ {
                 "viewable": 0
             } """

--- a/tests/Jawa/Event/VisualQualityTest.elm
+++ b/tests/Jawa/Event/VisualQualityTest.elm
@@ -17,10 +17,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.VisualQuality"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.VisualQuality.decoder Jawa.Event.VisualQuality.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.VisualQuality.decoder Jawa.Event.VisualQuality.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.VisualQuality.decoder
-            Jawa.Event.VisualQuality.encoder
+            Jawa.Event.VisualQuality.encode
             """ {
                 "level": {
                     "bitrate": 0,

--- a/tests/Jawa/Event/VolumeTest.elm
+++ b/tests/Jawa/Event/VolumeTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event.Volume"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Volume.decoder Jawa.Event.Volume.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.Volume.decoder Jawa.Event.Volume.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Event.Volume.decoder
-            Jawa.Event.Volume.encoder
+            Jawa.Event.Volume.encode
             """ {
                 "volume": 0.1
             } """

--- a/tests/Jawa/EventTest.elm
+++ b/tests/Jawa/EventTest.elm
@@ -58,10 +58,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Event"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.decoder Jawa.Event.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Event.decoder Jawa.Event.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with audioTracks"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "currentTrack": 0,
                 "tracks": [],
@@ -74,14 +74,14 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with beforeComplete"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "beforeComplete"
             } """
             (Jawa.Event.BeforeComplete {})
         , Jawa.Extra.Test.testCodec "works with beforePlay"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "playReason": "autostart",
                 "type": "beforePlay",
@@ -94,7 +94,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with breakpoint"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "breakpoint": 0,
                 "type": "breakpoint"
@@ -105,7 +105,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with buffer"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "oldstate": "idle",
                 "newstate": "buffering",
@@ -120,7 +120,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with bufferChange"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "bufferPercent": 0.1,
                 "currentTime": 0.2,
@@ -145,14 +145,14 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with bufferFull"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "bufferFull"
             } """
             (Jawa.Event.BufferFull {})
         , Jawa.Extra.Test.testCodec "works with captionsChanged"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "track": 0,
                 "tracks": [],
@@ -165,7 +165,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with captionsList"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "track": 0,
                 "tracks": [],
@@ -178,7 +178,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with click"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "isTrusted": false,
                 "type": "click"
@@ -189,14 +189,14 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with complete"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "complete"
             } """
             (Jawa.Event.Complete {})
         , Jawa.Extra.Test.testCodec "works with controls"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "controls": false,
                 "type": "controls"
@@ -207,14 +207,14 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with displayClick"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "displayClick"
             } """
             (Jawa.Event.DisplayClick {})
         , Jawa.Extra.Test.testCodec "works with firstFrame"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "loadTime": 0.1,
                 "type": "firstFrame"
@@ -225,7 +225,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with fullscreen"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "fullscreen": false,
                 "type": "fullscreen"
@@ -236,7 +236,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with idle"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "newstate": "buffering",
                 "oldstate": "complete",
@@ -251,7 +251,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with mediaType"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "mediaType": "audio",
                 "type": "mediaType"
@@ -262,7 +262,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with mute"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "mute": false,
                 "type": "mute"
@@ -273,7 +273,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with pause"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "newstate": "buffering",
                 "oldstate": "complete",
@@ -292,21 +292,21 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with pipEnter"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "pipEnter"
             } """
             (Jawa.Event.PipEnter {})
         , Jawa.Extra.Test.testCodec "works with pipLeave"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "pipLeave"
             } """
             (Jawa.Event.PipLeave {})
         , Jawa.Extra.Test.testCodec "works with play"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "newstate": "buffering",
                 "oldstate": "complete",
@@ -325,7 +325,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with playbackRateChanged"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "playbackRate": 0.1,
                 "type": "playbackRateChanged"
@@ -336,7 +336,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with playlist"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "playlist": [],
                 "type": "playlist"
@@ -347,14 +347,14 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with playlistComplete"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "playlistComplete"
             } """
             (Jawa.Event.PlaylistComplete {})
         , Jawa.Extra.Test.testCodec "works with playlistItem"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "index": 0,
                 "item": {
@@ -383,14 +383,14 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with providerFirstFrame"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "providerFirstFrame"
             } """
             (Jawa.Event.ProviderFirstFrame {})
         , Jawa.Extra.Test.testCodec "works with ready"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "setupTime": 0.1,
                 "viewable": 0,
@@ -403,14 +403,14 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with remove"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "remove"
             } """
             (Jawa.Event.Remove {})
         , Jawa.Extra.Test.testCodec "works with resize"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "height": 0,
                 "type": "resize",
@@ -423,7 +423,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with seek"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "currentTime": 0.1,
                 "duration": 0.2,
@@ -450,14 +450,14 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with seeked"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "seeked"
             } """
             (Jawa.Event.Seeked {})
         , Jawa.Extra.Test.testCodec "works with setupError"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "code": 0,
                 "message": "",
@@ -470,7 +470,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with time"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "currentTime": 0.1,
                 "duration": 0.2,
@@ -497,21 +497,21 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with userActive"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "userActive"
             } """
             (Jawa.Event.UserActive {})
         , Jawa.Extra.Test.testCodec "works with userInactive"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "userInactive"
             } """
             (Jawa.Event.UserInactive {})
         , Jawa.Extra.Test.testCodec "works with viewable"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "viewable": 0,
                 "type": "viewable"
@@ -522,7 +522,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with visualQuality"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "level": {
                     "bitrate": 0,
@@ -549,7 +549,7 @@ test =
             )
         , Jawa.Extra.Test.testCodec "works with volume"
             Jawa.Event.decoder
-            Jawa.Event.encoder
+            Jawa.Event.encode
             """ {
                 "type": "volume",
                 "volume": 0.1

--- a/tests/Jawa/Extra/Test.elm
+++ b/tests/Jawa/Extra/Test.elm
@@ -11,10 +11,10 @@ import Test
 
 
 expectCodec : Json.Decode.Decoder a -> (a -> Json.Encode.Value) -> String -> a -> Expect.Expectation
-expectCodec decoder encoder string =
+expectCodec decoder encode string =
     Expect.all
         [ expectDecoder decoder string
-        , expectEncoder encoder string
+        , expectEncoder encode string
         ]
 
 
@@ -26,28 +26,28 @@ expectDecoder decoder string value =
 
 
 expectEncoder : (a -> Json.Encode.Value) -> String -> a -> Expect.Expectation
-expectEncoder encoder string value =
+expectEncoder encode string value =
     case Json.Decode.decodeString Json.Decode.value string of
         Err message ->
             Expect.fail (Json.Decode.errorToString message)
 
         Ok json ->
             Expect.equal
-                (encoder value)
+                (encode value)
                 json
 
 
 fuzzCodec : String -> Json.Decode.Decoder a -> (a -> Json.Encode.Value) -> Fuzz.Fuzzer a -> Test.Test
-fuzzCodec label decoder encoder fuzzer =
+fuzzCodec label decoder encode fuzzer =
     Test.fuzz fuzzer label <|
         \value ->
             expectCodec
                 decoder
-                encoder
-                (Json.Encode.encode 0 (encoder value))
+                encode
+                (Json.Encode.encode 0 (encode value))
                 value
 
 
 testCodec : String -> Json.Decode.Decoder a -> (a -> Json.Encode.Value) -> String -> a -> Test.Test
-testCodec label decoder encoder string value =
-    Test.test label <| \_ -> expectCodec decoder encoder string value
+testCodec label decoder encode string value =
+    Test.test label <| \_ -> expectCodec decoder encode string value

--- a/tests/Jawa/Extra/Test.elm
+++ b/tests/Jawa/Extra/Test.elm
@@ -14,7 +14,7 @@ expectCodec : Json.Decode.Decoder a -> (a -> Json.Encode.Value) -> String -> a -
 expectCodec decoder encode string =
     Expect.all
         [ expectDecoder decoder string
-        , expectEncoder encode string
+        , expectEncode encode string
         ]
 
 
@@ -25,8 +25,8 @@ expectDecoder decoder string value =
         (Ok value)
 
 
-expectEncoder : (a -> Json.Encode.Value) -> String -> a -> Expect.Expectation
-expectEncoder encode string value =
+expectEncode : (a -> Json.Encode.Value) -> String -> a -> Expect.Expectation
+expectEncode encode string value =
     case Json.Decode.decodeString Json.Decode.value string of
         Err message ->
             Expect.fail (Json.Decode.errorToString message)

--- a/tests/Jawa/MediaTypeTest.elm
+++ b/tests/Jawa/MediaTypeTest.elm
@@ -12,15 +12,15 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.MediaType"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.MediaType.decoder Jawa.MediaType.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.MediaType.decoder Jawa.MediaType.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with audio"
             Jawa.MediaType.decoder
-            Jawa.MediaType.encoder
+            Jawa.MediaType.encode
             "\"audio\""
             Jawa.MediaType.Audio
         , Jawa.Extra.Test.testCodec "works with video"
             Jawa.MediaType.decoder
-            Jawa.MediaType.encoder
+            Jawa.MediaType.encode
             "\"video\""
             Jawa.MediaType.Video
         ]

--- a/tests/Jawa/MetadataTest.elm
+++ b/tests/Jawa/MetadataTest.elm
@@ -10,10 +10,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Metadata"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Metadata.decoder Jawa.Metadata.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Metadata.decoder Jawa.Metadata.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Metadata.decoder
-            Jawa.Metadata.encoder
+            Jawa.Metadata.encode
             "null"
             (Jawa.Metadata.Metadata Json.Encode.null)
         ]

--- a/tests/Jawa/PauseReasonTest.elm
+++ b/tests/Jawa/PauseReasonTest.elm
@@ -12,20 +12,20 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.PauseReason"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.PauseReason.decoder Jawa.PauseReason.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.PauseReason.decoder Jawa.PauseReason.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with external"
             Jawa.PauseReason.decoder
-            Jawa.PauseReason.encoder
+            Jawa.PauseReason.encode
             "\"external\""
             Jawa.PauseReason.External
         , Jawa.Extra.Test.testCodec "works with interaction"
             Jawa.PauseReason.decoder
-            Jawa.PauseReason.encoder
+            Jawa.PauseReason.encode
             "\"interaction\""
             Jawa.PauseReason.Interaction
         , Jawa.Extra.Test.testCodec "works with viewable"
             Jawa.PauseReason.decoder
-            Jawa.PauseReason.encoder
+            Jawa.PauseReason.encode
             "\"viewable\""
             Jawa.PauseReason.Viewable
         ]

--- a/tests/Jawa/PlayReasonTest.elm
+++ b/tests/Jawa/PlayReasonTest.elm
@@ -12,35 +12,35 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.PlayReason"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.PlayReason.decoder Jawa.PlayReason.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.PlayReason.decoder Jawa.PlayReason.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with autostart"
             Jawa.PlayReason.decoder
-            Jawa.PlayReason.encoder
+            Jawa.PlayReason.encode
             "\"autostart\""
             Jawa.PlayReason.Autostart
         , Jawa.Extra.Test.testCodec "works with external"
             Jawa.PlayReason.decoder
-            Jawa.PlayReason.encoder
+            Jawa.PlayReason.encode
             "\"external\""
             Jawa.PlayReason.External
         , Jawa.Extra.Test.testCodec "works with interaction"
             Jawa.PlayReason.decoder
-            Jawa.PlayReason.encoder
+            Jawa.PlayReason.encode
             "\"interaction\""
             Jawa.PlayReason.Interaction
         , Jawa.Extra.Test.testCodec "works with playlist"
             Jawa.PlayReason.decoder
-            Jawa.PlayReason.encoder
+            Jawa.PlayReason.encode
             "\"playlist\""
             Jawa.PlayReason.Playlist
         , Jawa.Extra.Test.testCodec "works with related-auto"
             Jawa.PlayReason.decoder
-            Jawa.PlayReason.encoder
+            Jawa.PlayReason.encode
             "\"related-auto\""
             Jawa.PlayReason.RelatedAuto
         , Jawa.Extra.Test.testCodec "works with related-interaction"
             Jawa.PlayReason.decoder
-            Jawa.PlayReason.encoder
+            Jawa.PlayReason.encode
             "\"related-interaction\""
             Jawa.PlayReason.RelatedInteraction
         ]

--- a/tests/Jawa/PlaylistItemTest.elm
+++ b/tests/Jawa/PlaylistItemTest.elm
@@ -16,10 +16,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.PlaylistItem"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.PlaylistItem.decoder Jawa.PlaylistItem.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.PlaylistItem.decoder Jawa.PlaylistItem.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with missing fields"
             Jawa.PlaylistItem.decoder
-            Jawa.PlaylistItem.encoder
+            Jawa.PlaylistItem.encode
             """ {
                 "allSources": [],
                 "file": "a",
@@ -39,7 +39,7 @@ test =
             }
         , Jawa.Extra.Test.testCodec "works with null fields"
             Jawa.PlaylistItem.decoder
-            Jawa.PlaylistItem.encoder
+            Jawa.PlaylistItem.encode
             """ {
                 "allSources": [],
                 "description": null,
@@ -63,7 +63,7 @@ test =
             }
         , Jawa.Extra.Test.testCodec "works with non-null fields"
             Jawa.PlaylistItem.decoder
-            Jawa.PlaylistItem.encoder
+            Jawa.PlaylistItem.encode
             """ {
                 "allSources": [],
                 "description": "a",

--- a/tests/Jawa/PreloadTest.elm
+++ b/tests/Jawa/PreloadTest.elm
@@ -12,20 +12,20 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Preload"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Preload.decoder Jawa.Preload.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Preload.decoder Jawa.Preload.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with auto"
             Jawa.Preload.decoder
-            Jawa.Preload.encoder
+            Jawa.Preload.encode
             "\"auto\""
             Jawa.Preload.Auto
         , Jawa.Extra.Test.testCodec "works with metadata"
             Jawa.Preload.decoder
-            Jawa.Preload.encoder
+            Jawa.Preload.encode
             "\"metadata\""
             Jawa.Preload.Metadata
         , Jawa.Extra.Test.testCodec "works with none"
             Jawa.Preload.decoder
-            Jawa.Preload.encoder
+            Jawa.Preload.encode
             "\"none\""
             Jawa.Preload.None
         ]

--- a/tests/Jawa/QualityLevelTest.elm
+++ b/tests/Jawa/QualityLevelTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.QualityLevel"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.QualityLevel.decoder Jawa.QualityLevel.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.QualityLevel.decoder Jawa.QualityLevel.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.QualityLevel.decoder
-            Jawa.QualityLevel.encoder
+            Jawa.QualityLevel.encode
             """ {
                 "bitrate": 0,
                 "height": 1,

--- a/tests/Jawa/QualityModeTest.elm
+++ b/tests/Jawa/QualityModeTest.elm
@@ -12,15 +12,15 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.QualityMode"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.QualityMode.decoder Jawa.QualityMode.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.QualityMode.decoder Jawa.QualityMode.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with auto"
             Jawa.QualityMode.decoder
-            Jawa.QualityMode.encoder
+            Jawa.QualityMode.encode
             "\"auto\""
             Jawa.QualityMode.Auto
         , Jawa.Extra.Test.testCodec "works with manual"
             Jawa.QualityMode.decoder
-            Jawa.QualityMode.encoder
+            Jawa.QualityMode.encode
             "\"manual\""
             Jawa.QualityMode.Manual
         ]

--- a/tests/Jawa/QualityReasonTest.elm
+++ b/tests/Jawa/QualityReasonTest.elm
@@ -12,20 +12,20 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.QualityReason"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.QualityReason.decoder Jawa.QualityReason.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.QualityReason.decoder Jawa.QualityReason.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with api"
             Jawa.QualityReason.decoder
-            Jawa.QualityReason.encoder
+            Jawa.QualityReason.encode
             "\"api\""
             Jawa.QualityReason.Api
         , Jawa.Extra.Test.testCodec "works with auto"
             Jawa.QualityReason.decoder
-            Jawa.QualityReason.encoder
+            Jawa.QualityReason.encode
             "\"auto\""
             Jawa.QualityReason.Auto
         , Jawa.Extra.Test.testCodec "works with initial choice"
             Jawa.QualityReason.decoder
-            Jawa.QualityReason.encoder
+            Jawa.QualityReason.encode
             "\"initial choice\""
             Jawa.QualityReason.InitialChoice
         ]

--- a/tests/Jawa/SeekRangeTest.elm
+++ b/tests/Jawa/SeekRangeTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.SeekRange"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.SeekRange.decoder Jawa.SeekRange.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.SeekRange.decoder Jawa.SeekRange.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.SeekRange.decoder
-            Jawa.SeekRange.encoder
+            Jawa.SeekRange.encode
             """ {
                 "end": 0.1,
                 "start": 0.2

--- a/tests/Jawa/SourceTest.elm
+++ b/tests/Jawa/SourceTest.elm
@@ -12,10 +12,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Source"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Source.decoder Jawa.Source.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Source.decoder Jawa.Source.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Source.decoder
-            Jawa.Source.encoder
+            Jawa.Source.encode
             """ {
                 "default": false,
                 "file": "a",

--- a/tests/Jawa/StateTest.elm
+++ b/tests/Jawa/StateTest.elm
@@ -12,45 +12,45 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.State"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.State.decoder Jawa.State.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.State.decoder Jawa.State.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with buffering"
             Jawa.State.decoder
-            Jawa.State.encoder
+            Jawa.State.encode
             "\"buffering\""
             Jawa.State.Buffering
         , Jawa.Extra.Test.testCodec "works with complete"
             Jawa.State.decoder
-            Jawa.State.encoder
+            Jawa.State.encode
             "\"complete\""
             Jawa.State.Complete
         , Jawa.Extra.Test.testCodec "works with error"
             Jawa.State.decoder
-            Jawa.State.encoder
+            Jawa.State.encode
             "\"error\""
             Jawa.State.Error
         , Jawa.Extra.Test.testCodec "works with idle"
             Jawa.State.decoder
-            Jawa.State.encoder
+            Jawa.State.encode
             "\"idle\""
             Jawa.State.Idle
         , Jawa.Extra.Test.testCodec "works with loading"
             Jawa.State.decoder
-            Jawa.State.encoder
+            Jawa.State.encode
             "\"loading\""
             Jawa.State.Loading
         , Jawa.Extra.Test.testCodec "works with paused"
             Jawa.State.decoder
-            Jawa.State.encoder
+            Jawa.State.encode
             "\"paused\""
             Jawa.State.Paused
         , Jawa.Extra.Test.testCodec "works with playing"
             Jawa.State.decoder
-            Jawa.State.encoder
+            Jawa.State.encode
             "\"playing\""
             Jawa.State.Playing
         , Jawa.Extra.Test.testCodec "works with stalled"
             Jawa.State.decoder
-            Jawa.State.encoder
+            Jawa.State.encode
             "\"stalled\""
             Jawa.State.Stalled
         ]

--- a/tests/Jawa/TrackKindTest.elm
+++ b/tests/Jawa/TrackKindTest.elm
@@ -12,20 +12,20 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.TrackKind"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.TrackKind.decoder Jawa.TrackKind.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.TrackKind.decoder Jawa.TrackKind.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with captions"
             Jawa.TrackKind.decoder
-            Jawa.TrackKind.encoder
+            Jawa.TrackKind.encode
             "\"captions\""
             Jawa.TrackKind.Captions
         , Jawa.Extra.Test.testCodec "works with chapters"
             Jawa.TrackKind.decoder
-            Jawa.TrackKind.encoder
+            Jawa.TrackKind.encode
             "\"chapters\""
             Jawa.TrackKind.Chapters
         , Jawa.Extra.Test.testCodec "works with thumbnails"
             Jawa.TrackKind.decoder
-            Jawa.TrackKind.encoder
+            Jawa.TrackKind.encode
             "\"thumbnails\""
             Jawa.TrackKind.Thumbnails
         ]

--- a/tests/Jawa/TrackTest.elm
+++ b/tests/Jawa/TrackTest.elm
@@ -14,10 +14,10 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Track"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Track.decoder Jawa.Track.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Track.decoder Jawa.Track.encode fuzzer
         , Jawa.Extra.Test.testCodec "works"
             Jawa.Track.decoder
-            Jawa.Track.encoder
+            Jawa.Track.encode
             """ {
                 "file": "a",
                 "kind": "captions",

--- a/tests/Jawa/ViewableTest.elm
+++ b/tests/Jawa/ViewableTest.elm
@@ -12,15 +12,15 @@ import Test
 test : Test.Test
 test =
     Test.describe "Jawa.Viewable"
-        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Viewable.decoder Jawa.Viewable.encoder fuzzer
+        [ Jawa.Extra.Test.fuzzCodec "round trips" Jawa.Viewable.decoder Jawa.Viewable.encode fuzzer
         , Jawa.Extra.Test.testCodec "works with hidden"
             Jawa.Viewable.decoder
-            Jawa.Viewable.encoder
+            Jawa.Viewable.encode
             "0"
             Jawa.Viewable.Hidden
         , Jawa.Extra.Test.testCodec "works with visible"
             Jawa.Viewable.decoder
-            Jawa.Viewable.encoder
+            Jawa.Viewable.encode
             "1"
             Jawa.Viewable.Visible
         ]


### PR DESCRIPTION
I think the latter is more idiomatic for Elm. 