### PR TITLE
Make current time and position optional on seek events

### DIFF
--- a/tests/Jawa/Event/SeekTest.elm
+++ b/tests/Jawa/Event/SeekTest.elm
@@ -31,11 +31,11 @@ test =
                     "start": 0.6
                 }
             } """
-            { currentTime = 0.1
+            { currentTime = Just 0.1
             , duration = 0.2
             , metadata = Jawa.Metadata.Metadata Json.Encode.null
             , offset = 0.3
-            , position = 0.4
+            , position = Just 0.4
             , seekRange =
                 { end = 0.5
                 , start = 0.6
@@ -47,9 +47,9 @@ test =
 fuzzer : Fuzz.Fuzzer Jawa.Event.Seek.Seek
 fuzzer =
     Fuzz.map6 Jawa.Event.Seek.Seek
-        Fuzz.niceFloat
+        (Fuzz.maybe Fuzz.niceFloat)
         Fuzz.niceFloat
         Jawa.MetadataTest.fuzzer
         Fuzz.niceFloat
-        Fuzz.niceFloat
+        (Fuzz.maybe Fuzz.niceFloat)
         Jawa.SeekRangeTest.fuzzer

--- a/tests/Jawa/EventTest.elm
+++ b/tests/Jawa/EventTest.elm
@@ -497,11 +497,11 @@ test =
                 "type": "seek"
             } """
             (Jawa.Event.Seek
-                { currentTime = 0.1
+                { currentTime = Just 0.1
                 , duration = 0.2
                 , metadata = Jawa.Metadata.Metadata Json.Encode.null
                 , offset = 0.3
-                , position = 0.4
+                , position = Just 0.4
                 , seekRange =
                     { end = 0.5
                     , start = 0.6


### PR DESCRIPTION
The `currentTime` and `position` fields on the seek event are apparently optional. I got an error like this:

> Problem with the value at json.currentTime: null Expecting a FLOAT

For this payload:

``` json
{
  "currentTime": null,
  "duration": 320.942426,
  "metadata": {
    "currentTime": null
  },
  "offset": 320.942426,
  "position": null,
  "seekRange": {
    "end": 320.942426,
    "start": 0
  },
  "type": "seek"
}
```